### PR TITLE
Fix minion role at boot time through cloud cfg

### DIFF
--- a/cluster/amazon/amazon.go
+++ b/cluster/amazon/amazon.go
@@ -91,7 +91,7 @@ func (clst *Cluster) Boot(bootSet []machine.Machine) error {
 	bootReqMap := make(map[bootReq]int64) // From boot request to an instance count.
 	for _, m := range bootSet {
 		br := bootReq{
-			cfg:      cloudcfg.Ubuntu(m.SSHKeys, "xenial"),
+			cfg:      cloudcfg.Ubuntu(m.SSHKeys, "xenial", m.Role),
 			size:     m.Size,
 			diskSize: m.DiskSize,
 		}

--- a/cluster/amazon/amazon_test.go
+++ b/cluster/amazon/amazon_test.go
@@ -421,16 +421,18 @@ func TestBoot(t *testing.T) {
 			Region:   DefaultRegion,
 			Size:     "m4.large",
 			DiskSize: 32,
+			Role:     db.Master,
 		},
 		{
 			Region:   DefaultRegion,
 			Size:     "m4.large",
 			DiskSize: 32,
+			Role:     db.Master,
 		},
 	})
 	assert.Nil(t, err)
 
-	cfg := cloudcfg.Ubuntu(nil, "xenial")
+	cfg := cloudcfg.Ubuntu(nil, "xenial", db.Master)
 	mc.AssertCalled(t, "RequestSpotInstances",
 		&ec2.RequestSpotInstancesInput{
 			SpotPrice: aws.String(spotPrice),

--- a/cluster/cloudcfg/cloudcfg.go
+++ b/cluster/cloudcfg/cloudcfg.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"text/template"
+
+	"github.com/quilt/quilt/db"
 )
 
 const (
@@ -12,7 +14,7 @@ const (
 
 // Ubuntu generates a cloud config file for the Ubuntu operating system with the
 // corresponding `version`.
-func Ubuntu(keys []string, version string) string {
+func Ubuntu(keys []string, version string, role db.Role) string {
 	t := template.Must(template.New("cloudConfig").Parse(cfgTemplate))
 
 	var cloudConfigBytes bytes.Buffer
@@ -20,10 +22,12 @@ func Ubuntu(keys []string, version string) string {
 		QuiltImage    string
 		UbuntuVersion string
 		SSHKeys       string
+		Role          string
 	}{
 		QuiltImage:    quiltImage,
 		UbuntuVersion: version,
 		SSHKeys:       strings.Join(keys, "\n"),
+		Role:          string(role),
 	})
 	if err != nil {
 		panic(err)

--- a/cluster/cloudcfg/cloudcfg_test.go
+++ b/cluster/cloudcfg/cloudcfg_test.go
@@ -1,13 +1,25 @@
 package cloudcfg
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/quilt/quilt/db"
+)
 
 func TestCloudConfig(t *testing.T) {
-	cfgTemplate = "({{.QuiltImage}}) ({{.SSHKeys}}) ({{.UbuntuVersion}})"
+	cfgTemplate = "({{.QuiltImage}}) ({{.SSHKeys}}) ({{.UbuntuVersion}}) " +
+		"({{.Role}})"
 
-	res := Ubuntu([]string{"a", "b"}, "1")
-	exp := "(quilt/quilt:latest) (a\nb) (1)"
+	res := Ubuntu([]string{"a", "b"}, "1", db.Master)
+	exp := "(quilt/quilt:latest) (a\nb) (1) (Master)"
 	if res != exp {
 		t.Errorf("res: %s\nexp: %s", res, exp)
 	}
+
+	res = Ubuntu([]string{"a", "b"}, "1", db.Worker)
+	exp = "(quilt/quilt:latest) (a\nb) (1) (Worker)"
+	if res != exp {
+		t.Errorf("res: %s\nexp: %s", res, exp)
+	}
+
 }

--- a/cluster/cloudcfg/template.go
+++ b/cluster/cloudcfg/template.go
@@ -62,7 +62,7 @@ initialize_minion() {
 	-v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
 	-v /home/quilt/.ssh:/home/quilt/.ssh:rw \
 	-v /run/docker:/run/docker:rw {{.QuiltImage}} \
-	quilt minion
+	quilt minion -role={{.Role}}
 	Restart=on-failure
 
 	[Install]

--- a/cluster/google/google.go
+++ b/cluster/google/google.go
@@ -150,7 +150,7 @@ func (clst *Cluster) Boot(bootSet []machine.Machine) error {
 	for _, m := range bootSet {
 		name := "quilt-" + uuid.NewV4().String()
 		_, err := clst.instanceNew(name, m.Size,
-			cloudcfg.Ubuntu(m.SSHKeys, "xenial"))
+			cloudcfg.Ubuntu(m.SSHKeys, "xenial", m.Role))
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,

--- a/cluster/machine/machine.go
+++ b/cluster/machine/machine.go
@@ -28,6 +28,7 @@ type Machine struct {
 	SSHKeys    []string
 	Provider   db.Provider
 	Region     string
+	Role       db.Role
 }
 
 // ChooseSize returns an acceptable machine size for the given provider that fits the

--- a/cluster/vagrant/vagrant.go
+++ b/cluster/vagrant/vagrant.go
@@ -57,7 +57,7 @@ func (clst Cluster) Boot(bootSet []machine.Machine) error {
 func bootMachine(m machine.Machine) error {
 	id := uuid.NewV4().String()
 
-	err := initMachine(cloudcfg.Ubuntu(m.SSHKeys, "xenial"), m.Size, id)
+	err := initMachine(cloudcfg.Ubuntu(m.SSHKeys, "xenial", m.Role), m.Size, id)
 	if err == nil {
 		err = up(id)
 	}

--- a/db/minion.go
+++ b/db/minion.go
@@ -1,7 +1,5 @@
 package db
 
-import "errors"
-
 // The Minion table is instantiated on the minions with one row.  That row contains the
 // configuration that minion needs to operate, including its ID, Role, and IP address
 type Minion struct {
@@ -39,9 +37,9 @@ func (db Database) SelectFromMinion(check func(Minion) bool) []Minion {
 	return result
 }
 
-// MinionSelf returns the Minion Row corresponding to the currently running minion, or an
-// error if no such row exists.
-func (db Database) MinionSelf() (Minion, error) {
+// MinionSelf returns the Minion Row corresponding to the currently running minion.
+// If there is no Minion Row, it panics
+func (db Database) MinionSelf() Minion {
 	minions := db.SelectFromMinion(func(m Minion) bool {
 		return m.Self
 	})
@@ -51,24 +49,23 @@ func (db Database) MinionSelf() (Minion, error) {
 	}
 
 	if len(minions) == 0 {
-		return Minion{}, errors.New("no self minion")
+		panic("no minion labeled Self")
 	}
 
-	return minions[0], nil
+	return minions[0]
 }
 
-// MinionSelf returns the Minion Row corresponding to the currently running minion, or an
-// error if no such row exists.
-func (conn Conn) MinionSelf() (Minion, error) {
+// MinionSelf returns the Minion Row corresponding to the currently running minion.
+// If there is no Minion Row, it panics
+func (conn Conn) MinionSelf() Minion {
 	var m Minion
-	var err error
 
 	conn.Txn(MinionTable).Run(func(view Database) error {
-		m, err = view.MinionSelf()
+		m = view.MinionSelf()
 		return nil
 	})
 
-	return m, err
+	return m
 }
 
 // SelectFromMinion gets all minions in the database that satisfy the 'check'.

--- a/db/minion.go
+++ b/db/minion.go
@@ -10,7 +10,6 @@ type Minion struct {
 	Self           bool   `json:"-"`
 	Spec           string `json:"-" rowStringer:"omit"`
 	AuthorizedKeys string `json:"-" rowStringer:"omit"`
-	SupervisorInit bool   `json:"-"`
 
 	// Below fields are included in the JSON encoding.
 	Role       Role

--- a/minion/etcd/container.go
+++ b/minion/etcd/container.go
@@ -39,10 +39,7 @@ func runContainerOnce(conn db.Conn, store Store) error {
 }
 
 func updateLeader(conn db.Conn, store Store, etcdStr string) error {
-	self, err := conn.MinionSelf()
-	if err != nil {
-		return err
-	}
+	self := conn.MinionSelf()
 	myIP := self.PrivateIP
 
 	dbcs := conn.SelectFromContainer(func(dbc db.Container) bool {
@@ -55,7 +52,7 @@ func updateLeader(conn db.Conn, store Store, etcdStr string) error {
 		dbcs[i].Image = myIP + ":5000/" + dbcs[i].Image
 	}
 
-	err = writeEtcdSlice(store, containerPath, etcdStr, db.ContainerSlice(dbcs))
+	err := writeEtcdSlice(store, containerPath, etcdStr, db.ContainerSlice(dbcs))
 	if err != nil {
 		return fmt.Errorf("etcd write error: %s", err)
 	}
@@ -64,10 +61,7 @@ func updateLeader(conn db.Conn, store Store, etcdStr string) error {
 }
 
 func updateNonLeader(conn db.Conn, etcdStr string) {
-	self, err := conn.MinionSelf()
-	if err != nil {
-		return
-	}
+	self := conn.MinionSelf()
 
 	var rawEtcdDBCs, etcdDBCs []db.Container
 	json.Unmarshal([]byte(etcdStr), &rawEtcdDBCs)

--- a/minion/etcd/container_test.go
+++ b/minion/etcd/container_test.go
@@ -108,8 +108,7 @@ func TestRunContainerOnce(t *testing.T) {
 	assert.Equal(t, expDBC, dbcs[0])
 
 	conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		self, err := view.MinionSelf()
-		assert.NoError(t, err)
+		self := view.MinionSelf()
 		self.Role = db.Worker
 		self.PrivateIP = "1.2.3.4"
 		view.Commit(self)
@@ -125,8 +124,7 @@ func TestRunContainerOnce(t *testing.T) {
 	assert.Equal(t, expDBC, dbcs[0])
 
 	conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		self, err := view.MinionSelf()
-		assert.NoError(t, err)
+		self := view.MinionSelf()
 		self.PrivateIP = "1.2.3.5"
 		view.Commit(self)
 		return nil

--- a/minion/etcd/elector.go
+++ b/minion/etcd/elector.go
@@ -56,8 +56,8 @@ func campaign(conn db.Conn, store Store) {
 
 		etcdRows := conn.SelectFromEtcd(nil)
 
-		minion, err := conn.MinionSelf()
-		master := err == nil && minion.Role == db.Master && len(etcdRows) == 1
+		minion := conn.MinionSelf()
+		master := minion.Role == db.Master && len(etcdRows) == 1
 
 		if !master {
 			continue
@@ -70,6 +70,7 @@ func campaign(conn db.Conn, store Store) {
 
 		ttl := electionTTL * time.Second
 
+		var err error
 		if etcdRows[0].Leader {
 			err = store.Refresh(leaderKey, IP, ttl)
 		} else {

--- a/minion/etcd/minion.go
+++ b/minion/etcd/minion.go
@@ -109,8 +109,8 @@ func diffMinion(dbMinions, storeMinions []db.Minion) (del, add []db.Minion) {
 }
 
 func writeMinion(conn db.Conn, store Store) {
-	minion, err := conn.MinionSelf()
-	if err != nil || minion.PrivateIP == "" {
+	minion := conn.MinionSelf()
+	if minion.PrivateIP == "" {
 		return
 	}
 

--- a/minion/etcd/minion_test.go
+++ b/minion/etcd/minion_test.go
@@ -18,11 +18,6 @@ func TestWriteMinion(t *testing.T) {
 	conn := db.New()
 	store := NewMock()
 
-	writeMinion(conn, store)
-	val, err := store.Get(key)
-	assert.NotNil(t, err)
-	assert.Empty(t, val)
-
 	// Minion without a PrivateIP
 	conn.Txn(db.AllTables...).Run(func(view db.Database) error {
 		m := view.InsertMinion()
@@ -36,12 +31,12 @@ func TestWriteMinion(t *testing.T) {
 	})
 
 	writeMinion(conn, store)
-	val, err = store.Get(key)
+	val, err := store.Get(key)
 	assert.NotNil(t, err)
 	assert.Empty(t, val)
 
 	conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		m.PrivateIP = ip
 		view.Commit(m)
 		return nil

--- a/minion/keys.go
+++ b/minion/keys.go
@@ -2,7 +2,6 @@ package minion
 
 import (
 	"os"
-	"time"
 
 	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/util"
@@ -13,20 +12,10 @@ import (
 const authorizedKeysFile = "/home/quilt/.ssh/authorized_keys"
 
 func syncAuthorizedKeys(conn db.Conn) {
-	waitForMinion(conn)
 	for range conn.TriggerTick(30, db.MinionTable).C {
 		if err := runOnce(conn); err != nil {
 			log.WithError(err).Error("Failed to sync keys")
 		}
-	}
-}
-
-func waitForMinion(conn db.Conn) {
-	for {
-		if _, err := conn.MinionSelf(); err == nil {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
 	}
 }
 
@@ -39,10 +28,7 @@ func runOnce(conn db.Conn) error {
 		return err
 	}
 
-	m, err := conn.MinionSelf()
-	if err != nil {
-		return err
-	}
+	m := conn.MinionSelf()
 
 	if m.AuthorizedKeys == currKeys {
 		return nil

--- a/minion/keys_test.go
+++ b/minion/keys_test.go
@@ -65,8 +65,9 @@ func TestSyncKeysError(t *testing.T) {
 	util.AppFs = afero.NewMemMapFs()
 
 	conn := db.New()
-	err := runOnce(conn)
-	assert.EqualError(t, err, "no self minion")
+	assert.Panics(t, func() {
+		runOnce(conn)
+	}, "running without MinionSelf should panic")
 
 	fs := afero.NewMemMapFs()
 	util.AppFs = afero.NewReadOnlyFs(fs)
@@ -77,7 +78,7 @@ func TestSyncKeysError(t *testing.T) {
 		view.Commit(m)
 		return nil
 	})
-	err = runOnce(conn)
+	err := runOnce(conn)
 	assert.EqualError(t, err, "open /home/quilt/.ssh/authorized_keys: "+
 		"file does not exist")
 

--- a/minion/network/dns.go
+++ b/minion/network/dns.go
@@ -98,11 +98,7 @@ func joinHostnames(view db.Database) error {
 }
 
 func serveDNSOnce(conn db.Conn) {
-	self, err := conn.MinionSelf()
-	if err != nil {
-		log.WithError(err).Debug("Failed to get self")
-		return
-	}
+	self := conn.MinionSelf()
 
 	if self.Role != db.Worker {
 		if table == nil {

--- a/minion/network/dns.go
+++ b/minion/network/dns.go
@@ -117,10 +117,6 @@ func serveDNSOnce(conn db.Conn) {
 		return
 	}
 
-	if !self.SupervisorInit {
-		return
-	}
-
 	table = updateTable(table, conn.SelectFromHostname(nil))
 }
 

--- a/minion/network/nat.go
+++ b/minion/network/nat.go
@@ -26,7 +26,7 @@ func runNat(conn db.Conn) {
 	tables := []db.TableType{db.ContainerTable, db.ConnectionTable, db.MinionTable}
 	for range conn.TriggerTick(30, tables...).C {
 		minion, err := conn.MinionSelf()
-		if err != nil || !minion.SupervisorInit || minion.Role != db.Worker {
+		if err != nil || minion.Role != db.Worker {
 			continue
 		}
 

--- a/minion/network/nat.go
+++ b/minion/network/nat.go
@@ -25,8 +25,8 @@ type IPTables interface {
 func runNat(conn db.Conn) {
 	tables := []db.TableType{db.ContainerTable, db.ConnectionTable, db.MinionTable}
 	for range conn.TriggerTick(30, tables...).C {
-		minion, err := conn.MinionSelf()
-		if err != nil || minion.Role != db.Worker {
+		minion := conn.MinionSelf()
+		if minion.Role != db.Worker {
 			continue
 		}
 

--- a/minion/network/network_test.go
+++ b/minion/network/network_test.go
@@ -36,7 +36,6 @@ func TestRunMaster(t *testing.T) {
 		view.Commit(etcd)
 
 		minion := view.InsertMinion()
-		minion.SupervisorInit = true
 		minion.Self = true
 		view.Commit(minion)
 

--- a/minion/registry/registry.go
+++ b/minion/registry/registry.go
@@ -36,8 +36,8 @@ func Run(conn db.Conn, dk docker.Client) {
 }
 
 func runOnce(conn db.Conn, dk docker.Client) {
-	self, err := conn.MinionSelf()
-	if err != nil || self.Role != db.Master {
+	self := conn.MinionSelf()
+	if self.Role != db.Master {
 		return
 	}
 

--- a/minion/run.go
+++ b/minion/run.go
@@ -35,11 +35,7 @@ func Run(role db.Role) {
 	// Possibly in the future just pass down role into all of the modules,
 	// but may be simpler to just have it use this entry.
 	conn.Txn(db.MinionTable).Run(func(view db.Database) error {
-		minion, err := view.MinionSelf()
-		if err != nil {
-			log.Info("Using role from cloudcfg.")
-			minion = view.InsertMinion()
-		}
+		minion := view.InsertMinion()
 		minion.Role = role
 		minion.Self = true
 		view.Commit(minion)
@@ -67,8 +63,8 @@ func Run(role db.Role) {
 		txn := conn.Txn(db.ConnectionTable, db.ContainerTable, db.MinionTable,
 			db.EtcdTable, db.PlacementTable, db.ImageTable)
 		txn.Run(func(view db.Database) error {
-			minion, err := view.MinionSelf()
-			if err == nil && view.EtcdLeader() {
+			minion := view.MinionSelf()
+			if view.EtcdLeader() {
 				updatePolicy(view, minion.Spec)
 			}
 			return nil

--- a/minion/run.go
+++ b/minion/run.go
@@ -49,8 +49,9 @@ func Run(role db.Role) {
 	// Not in a goroutine, want the plugin to start before the scheduler
 	plugin.Run()
 
+	supervisor.Run(conn, dk, role)
+
 	go minionServerRun(conn)
-	go supervisor.Run(conn, dk, role)
 	go scheduler.Run(conn, dk)
 	go network.Run(conn)
 	go registry.Run(conn, dk)

--- a/minion/run.go
+++ b/minion/run.go
@@ -30,9 +30,6 @@ func Run(role db.Role) {
 	conn := db.New()
 	dk := docker.New("unix:///var/run/docker.sock")
 
-	// Not in a goroutine, want the plugin to start before the scheduler
-	plugin.Run()
-
 	// XXX: As we are developing minion modules to use this passed down role
 	// instead of querying their db independently, we need to do this.
 	// Possibly in the future just pass down role into all of the modules,
@@ -48,6 +45,9 @@ func Run(role db.Role) {
 		view.Commit(minion)
 		return nil
 	})
+
+	// Not in a goroutine, want the plugin to start before the scheduler
+	plugin.Run()
 
 	go minionServerRun(conn)
 	go supervisor.Run(conn, dk, role)

--- a/minion/scheduler/scheduler.go
+++ b/minion/scheduler/scheduler.go
@@ -35,7 +35,7 @@ func Run(conn db.Conn, dk docker.Client) {
 			continue
 		}
 
-		if minion.Role == db.Worker && minion.SupervisorInit {
+		if minion.Role == db.Worker {
 			runWorker(conn, dk, minion.PrivateIP)
 		} else if minion.Role == db.Master {
 			runMaster(conn)

--- a/minion/scheduler/scheduler.go
+++ b/minion/scheduler/scheduler.go
@@ -29,11 +29,7 @@ func Run(conn db.Conn, dk docker.Client) {
 		db.PlacementTable, db.EtcdTable).C
 	for range trig {
 		loopLog.LogStart()
-		minion, err := conn.MinionSelf()
-		if err != nil {
-			log.WithError(err).Warn("Missing self in the minion table.")
-			continue
-		}
+		minion := conn.MinionSelf()
 
 		if minion.Role == db.Worker {
 			runWorker(conn, dk, minion.PrivateIP)

--- a/minion/server.go
+++ b/minion/server.go
@@ -44,17 +44,14 @@ func (s server) GetMinionConfig(cts context.Context,
 
 	var cfg pb.MinionConfig
 
-	if m, err := s.MinionSelf(); err == nil {
-		cfg.Role = db.RoleToPB(m.Role)
-		cfg.PrivateIP = m.PrivateIP
-		cfg.Spec = m.Spec
-		cfg.Provider = m.Provider
-		cfg.Size = m.Size
-		cfg.Region = m.Region
-		cfg.AuthorizedKeys = strings.Split(m.AuthorizedKeys, "\n")
-	} else {
-		cfg.Role = db.RoleToPB(db.None)
-	}
+	m := s.MinionSelf()
+	cfg.Role = db.RoleToPB(m.Role)
+	cfg.PrivateIP = m.PrivateIP
+	cfg.Spec = m.Spec
+	cfg.Provider = m.Provider
+	cfg.Size = m.Size
+	cfg.Region = m.Region
+	cfg.AuthorizedKeys = strings.Split(m.AuthorizedKeys, "\n")
 
 	s.Txn(db.EtcdTable).Run(func(view db.Database) error {
 		if etcdRow, err := view.GetEtcd(); err == nil {
@@ -71,12 +68,7 @@ func (s server) SetMinionConfig(ctx context.Context,
 	go s.Txn(db.EtcdTable,
 		db.MinionTable).Run(func(view db.Database) error {
 
-		minion, err := view.MinionSelf()
-		if err != nil {
-			log.WithError(err).Error("Role not obtained from cloudcfg.")
-			minion = view.InsertMinion()
-		}
-
+		minion := view.MinionSelf()
 		minion.PrivateIP = msg.PrivateIP
 		minion.Spec = msg.Spec
 		minion.Provider = msg.Provider

--- a/minion/server.go
+++ b/minion/server.go
@@ -73,11 +73,10 @@ func (s server) SetMinionConfig(ctx context.Context,
 
 		minion, err := view.MinionSelf()
 		if err != nil {
-			log.Info("Received initial configuation.")
+			log.WithError(err).Error("Role not obtained from cloudcfg.")
 			minion = view.InsertMinion()
 		}
 
-		minion.Role = db.PBToRole(msg.Role)
 		minion.PrivateIP = msg.PrivateIP
 		minion.Spec = msg.Spec
 		minion.Provider = msg.Provider

--- a/minion/server_test.go
+++ b/minion/server_test.go
@@ -16,7 +16,6 @@ func TestSetMinionConfig(t *testing.T) {
 	s := server{db.New()}
 
 	cfg := pb.MinionConfig{
-		Role:           pb.MinionConfig_MASTER,
 		PrivateIP:      "priv",
 		Spec:           "spec",
 		Provider:       "provider",
@@ -28,7 +27,6 @@ func TestSetMinionConfig(t *testing.T) {
 	expMinion := db.Minion{
 		Self:           true,
 		Spec:           "spec",
-		Role:           db.Master,
 		PrivateIP:      "priv",
 		Provider:       "provider",
 		Size:           "size",

--- a/minion/supervisor/master.go
+++ b/minion/supervisor/master.go
@@ -22,10 +22,7 @@ func runMasterSystem() {
 }
 
 func runMasterOnce() {
-	minion, err := conn.MinionSelf()
-	if err != nil {
-		return
-	}
+	minion := conn.MinionSelf()
 
 	var etcdRow db.Etcd
 	if etcdRows := conn.SelectFromEtcd(nil); len(etcdRows) == 1 {

--- a/minion/supervisor/master.go
+++ b/minion/supervisor/master.go
@@ -9,7 +9,6 @@ import (
 
 func runMaster() {
 	run(Ovsdb, "ovsdb-server")
-	SetInit()
 	go runMasterSystem()
 }
 

--- a/minion/supervisor/master.go
+++ b/minion/supervisor/master.go
@@ -1,0 +1,70 @@
+package supervisor
+
+import (
+	"fmt"
+
+	"github.com/quilt/quilt/db"
+	"github.com/quilt/quilt/util"
+)
+
+func runMaster() {
+	run(Ovsdb, "ovsdb-server")
+	SetInit()
+	go runMasterSystem()
+}
+
+func runMasterSystem() {
+	loopLog := util.NewEventTimer("Supervisor")
+	for range conn.Trigger(db.MinionTable, db.EtcdTable).C {
+		loopLog.LogStart()
+		runMasterOnce()
+		loopLog.LogEnd()
+	}
+}
+
+func runMasterOnce() {
+	minion, err := conn.MinionSelf()
+	if err != nil {
+		return
+	}
+
+	var etcdRow db.Etcd
+	if etcdRows := conn.SelectFromEtcd(nil); len(etcdRows) == 1 {
+		etcdRow = etcdRows[0]
+	}
+
+	IP := minion.PrivateIP
+	etcdIPs := etcdRow.EtcdIPs
+	leader := etcdRow.Leader
+
+	if oldIP != IP || !util.StrSliceEqual(oldEtcdIPs, etcdIPs) {
+		Remove(Etcd)
+	}
+
+	oldEtcdIPs = etcdIPs
+	oldIP = IP
+
+	if IP == "" || len(etcdIPs) == 0 {
+		return
+	}
+
+	run(Etcd, fmt.Sprintf("--name=master-%s", IP),
+		fmt.Sprintf("--initial-cluster=%s", initialClusterString(etcdIPs)),
+		fmt.Sprintf("--advertise-client-urls=http://%s:2379", IP),
+		fmt.Sprintf("--listen-peer-urls=http://%s:2380", IP),
+		fmt.Sprintf("--initial-advertise-peer-urls=http://%s:2380", IP),
+		"--listen-client-urls=http://0.0.0.0:2379",
+		"--heartbeat-interval="+etcdHeartbeatInterval,
+		"--initial-cluster-state=new",
+		"--election-timeout="+etcdElectionTimeout)
+	run(Ovsdb, "ovsdb-server")
+
+	if leader {
+		/* XXX: If we fail to boot ovn-northd, we should give up
+		* our leadership somehow.  This ties into the general
+		* problem of monitoring health. */
+		run(Ovnnorthd, "ovn-northd")
+	} else {
+		Remove(Ovnnorthd)
+	}
+}

--- a/minion/supervisor/master_test.go
+++ b/minion/supervisor/master_test.go
@@ -20,7 +20,7 @@ func TestNone(t *testing.T) {
 	}
 
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.PrivateIP = "1.2.3.4"
 		e.Leader = false
@@ -45,7 +45,7 @@ func TestMaster(t *testing.T) {
 	ip := "1.2.3.4"
 	etcdIPs := []string{""}
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Master
 		m.PrivateIP = ip
@@ -73,7 +73,7 @@ func TestMaster(t *testing.T) {
 	ip = "8.8.8.8"
 	etcdIPs = []string{"8.8.8.8"}
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Master
 		m.PrivateIP = ip
@@ -125,7 +125,7 @@ func TestEtcdAdd(t *testing.T) {
 	ip := "1.2.3.4"
 	etcdIPs := []string{ip, "5.6.7.8"}
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Master
 		m.PrivateIP = ip
@@ -148,7 +148,7 @@ func TestEtcdAdd(t *testing.T) {
 	// Add a new master
 	etcdIPs = append(etcdIPs, "9.10.11.12")
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Master
 		e.EtcdIPs = etcdIPs
@@ -173,7 +173,7 @@ func TestEtcdRemove(t *testing.T) {
 	ip := "1.2.3.4"
 	etcdIPs := []string{ip, "5.6.7.8"}
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Master
 		m.PrivateIP = ip
@@ -196,7 +196,7 @@ func TestEtcdRemove(t *testing.T) {
 	// Remove a master
 	etcdIPs = etcdIPs[1:]
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Master
 		e.EtcdIPs = etcdIPs

--- a/minion/supervisor/master_test.go
+++ b/minion/supervisor/master_test.go
@@ -1,0 +1,217 @@
+package supervisor
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/quilt/quilt/db"
+)
+
+func TestNone(t *testing.T) {
+	ctx := initTest(db.Master)
+
+	if len(ctx.fd.running()) > 0 {
+		t.Errorf("fd.running = %s; want <empty>", spew.Sdump(ctx.fd.running()))
+	}
+
+	if len(ctx.execs) > 0 {
+		t.Errorf("exec = %s; want <empty>", spew.Sdump(ctx.execs))
+	}
+
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.PrivateIP = "1.2.3.4"
+		e.Leader = false
+		e.LeaderIP = "5.6.7.8"
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	if len(ctx.fd.running()) > 0 {
+		t.Errorf("fd.running = %s; want <none>", spew.Sdump(ctx.fd.running()))
+	}
+
+	if len(ctx.execs) > 0 {
+		t.Errorf("exec = %s; want <empty>", spew.Sdump(ctx.execs))
+	}
+}
+
+func TestMaster(t *testing.T) {
+	ctx := initTest(db.Master)
+	ip := "1.2.3.4"
+	etcdIPs := []string{""}
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Master
+		m.PrivateIP = ip
+		e.EtcdIPs = etcdIPs
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp := map[string][]string{
+		Etcd:  etcdArgsMaster(ip, etcdIPs),
+		Ovsdb: {"ovsdb-server"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+
+	if len(ctx.execs) > 0 {
+		t.Errorf("exec = %s; want <empty>", spew.Sdump(ctx.execs))
+	}
+
+	/* Change IP, etcd IPs, and become the leader. */
+	ip = "8.8.8.8"
+	etcdIPs = []string{"8.8.8.8"}
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Master
+		m.PrivateIP = ip
+		e.EtcdIPs = etcdIPs
+		e.Leader = true
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp = map[string][]string{
+		Etcd:      etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:     {"ovsdb-server"},
+		Ovnnorthd: {"ovn-northd"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+	if len(ctx.execs) > 0 {
+		t.Errorf("exec = %s; want <empty>", spew.Sdump(ctx.execs))
+	}
+
+	/* Lose leadership. */
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		e := view.SelectFromEtcd(nil)[0]
+		e.Leader = false
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp = map[string][]string{
+		Etcd:  etcdArgsMaster(ip, etcdIPs),
+		Ovsdb: {"ovsdb-server"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+	if len(ctx.execs) > 0 {
+		t.Errorf("exec = %s; want <empty>", spew.Sdump(ctx.execs))
+	}
+}
+
+func TestEtcdAdd(t *testing.T) {
+	ctx := initTest(db.Master)
+	ip := "1.2.3.4"
+	etcdIPs := []string{ip, "5.6.7.8"}
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Master
+		m.PrivateIP = ip
+		e.EtcdIPs = etcdIPs
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp := map[string][]string{
+		Etcd:  etcdArgsMaster(ip, etcdIPs),
+		Ovsdb: {"ovsdb-server"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+
+	// Add a new master
+	etcdIPs = append(etcdIPs, "9.10.11.12")
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Master
+		e.EtcdIPs = etcdIPs
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp = map[string][]string{
+		Etcd:  etcdArgsMaster(ip, etcdIPs),
+		Ovsdb: {"ovsdb-server"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+}
+
+func TestEtcdRemove(t *testing.T) {
+	ctx := initTest(db.Master)
+	ip := "1.2.3.4"
+	etcdIPs := []string{ip, "5.6.7.8"}
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Master
+		m.PrivateIP = ip
+		e.EtcdIPs = etcdIPs
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp := map[string][]string{
+		Etcd:  etcdArgsMaster(ip, etcdIPs),
+		Ovsdb: {"ovsdb-server"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+
+	// Remove a master
+	etcdIPs = etcdIPs[1:]
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Master
+		e.EtcdIPs = etcdIPs
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp = map[string][]string{
+		Etcd:  etcdArgsMaster(ip, etcdIPs),
+		Ovsdb: {"ovsdb-server"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+}

--- a/minion/supervisor/supervisor.go
+++ b/minion/supervisor/supervisor.go
@@ -123,8 +123,6 @@ func (sv *supervisor) runSystemOnce() {
 			etcdRow.EtcdIPs)
 	}
 
-	sv.SetInit()
-
 	sv.etcdIPs = etcdRow.EtcdIPs
 	sv.leaderIP = etcdRow.LeaderIP
 	sv.IP = minion.PrivateIP
@@ -176,6 +174,8 @@ func (sv *supervisor) updateWorker(IP string, leaderIP string, etcdIPs []string)
 	 * So, we need to restart the container when the leader changes. */
 	sv.Remove(Ovncontroller)
 	sv.run(Ovncontroller, "ovn-controller")
+
+	sv.SetInit()
 }
 
 func (sv *supervisor) updateMaster(IP string, etcdIPs []string, leader bool) {
@@ -207,6 +207,8 @@ func (sv *supervisor) updateMaster(IP string, etcdIPs []string, leader bool) {
 	} else {
 		sv.Remove(Ovnnorthd)
 	}
+
+	sv.SetInit()
 }
 
 func (sv *supervisor) run(name string, args ...string) {

--- a/minion/supervisor/supervisor.go
+++ b/minion/supervisor/supervisor.go
@@ -2,15 +2,11 @@ package supervisor
 
 import (
 	"fmt"
-	"net"
 	"os/exec"
-	"reflect"
 	"strings"
 
 	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/minion/docker"
-	"github.com/quilt/quilt/minion/ipdef"
-	"github.com/quilt/quilt/util"
 	"github.com/vishvananda/netlink"
 
 	log "github.com/Sirupsen/logrus"
@@ -54,165 +50,38 @@ var images = map[string]string{
 const etcdHeartbeatInterval = "500"
 const etcdElectionTimeout = "5000"
 
-type supervisor struct {
-	conn db.Conn
-	dk   docker.Client
-
-	role     db.Role
-	etcdIPs  []string
-	leaderIP string
-	IP       string
-	leader   bool
-	provider string
-	region   string
-	size     string
-}
+var conn db.Conn
+var dk docker.Client
+var role db.Role
+var oldEtcdIPs []string
+var oldIP string
 
 // Run blocks implementing the supervisor module.
-func Run(conn db.Conn, dk docker.Client, role db.Role) {
-	sv := supervisor{conn: conn, dk: dk, role: role}
-	sv.runSystem()
-}
+func Run(_conn db.Conn, _dk docker.Client, _role db.Role) {
+	conn = _conn
+	dk = _dk
+	role = _role
 
-// Manage system infrstracture containers that support the application.
-func (sv *supervisor) runSystem() {
 	imageSet := map[string]struct{}{}
 	for _, image := range images {
 		imageSet[image] = struct{}{}
 	}
 
 	for image := range imageSet {
-		go sv.dk.Pull(image)
+		go dk.Pull(image)
 	}
 
-	loopLog := util.NewEventTimer("Supervisor")
-	for range sv.conn.Trigger(db.MinionTable, db.EtcdTable).C {
-		loopLog.LogStart()
-		sv.runSystemOnce()
-		loopLog.LogEnd()
-	}
-}
-
-func (sv *supervisor) runSystemOnce() {
-	minion, err := sv.conn.MinionSelf()
-	if err != nil {
-		return
-	}
-
-	var etcdRow db.Etcd
-	if etcdRows := sv.conn.SelectFromEtcd(nil); len(etcdRows) == 1 {
-		etcdRow = etcdRows[0]
-	}
-
-	if reflect.DeepEqual(sv.etcdIPs, etcdRow.EtcdIPs) &&
-		sv.leaderIP == etcdRow.LeaderIP &&
-		sv.IP == minion.PrivateIP &&
-		sv.leader == etcdRow.Leader &&
-		sv.provider == minion.Provider &&
-		sv.region == minion.Region &&
-		sv.size == minion.Size {
-		return
-	}
-
-	switch sv.role {
+	switch role {
 	case db.Master:
-		sv.updateMaster(minion.PrivateIP, etcdRow.EtcdIPs,
-			etcdRow.Leader)
+		runMaster()
 	case db.Worker:
-		sv.updateWorker(minion.PrivateIP, etcdRow.LeaderIP,
-			etcdRow.EtcdIPs)
+		runWorker()
 	}
-
-	sv.etcdIPs = etcdRow.EtcdIPs
-	sv.leaderIP = etcdRow.LeaderIP
-	sv.IP = minion.PrivateIP
-	sv.leader = etcdRow.Leader
-	sv.provider = minion.Provider
-	sv.region = minion.Region
-	sv.size = minion.Size
 }
 
-func (sv *supervisor) updateWorker(IP string, leaderIP string, etcdIPs []string) {
-	if !reflect.DeepEqual(sv.etcdIPs, etcdIPs) {
-		sv.Remove(Etcd)
-	}
-
-	sv.run(Etcd, fmt.Sprintf("--initial-cluster=%s", initialClusterString(etcdIPs)),
-		"--heartbeat-interval="+etcdHeartbeatInterval,
-		"--election-timeout="+etcdElectionTimeout,
-		"--proxy=on")
-
-	sv.run(Ovsdb, "ovsdb-server")
-	sv.run(Ovsvswitchd, "ovs-vswitchd")
-
-	if leaderIP == "" || IP == "" {
-		return
-	}
-
-	gwMac := ipdef.IPToMac(ipdef.GatewayIP)
-	err := execRun("ovs-vsctl", "set", "Open_vSwitch", ".",
-		fmt.Sprintf("external_ids:ovn-remote=\"tcp:%s:6640\"", leaderIP),
-		fmt.Sprintf("external_ids:ovn-encap-ip=%s", IP),
-		fmt.Sprintf("external_ids:ovn-encap-type=\"%s\"", tunnelingProtocol),
-		fmt.Sprintf("external_ids:api_server=\"http://%s:9000\"", leaderIP),
-		fmt.Sprintf("external_ids:system-id=\"%s\"", IP),
-		"--", "add-br", "quilt-int",
-		"--", "set", "bridge", "quilt-int", "fail_mode=secure",
-		fmt.Sprintf("other_config:hwaddr=\"%s\"", gwMac))
-	if err != nil {
-		log.WithError(err).Warnf("Failed to exec in %s.", Ovsvswitchd)
-		return
-	}
-
-	ip := net.IPNet{IP: ipdef.GatewayIP, Mask: ipdef.QuiltSubnet.Mask}
-	if err := cfgGateway("quilt-int", ip); err != nil {
-		log.WithError(err).Error("Failed to configure quilt-int.")
-		return
-	}
-
-	/* The ovn controller doesn't support reconfiguring ovn-remote mid-run.
-	 * So, we need to restart the container when the leader changes. */
-	sv.Remove(Ovncontroller)
-	sv.run(Ovncontroller, "ovn-controller")
-
-	sv.SetInit()
-}
-
-func (sv *supervisor) updateMaster(IP string, etcdIPs []string, leader bool) {
-	if sv.IP != IP || !reflect.DeepEqual(sv.etcdIPs, etcdIPs) {
-		sv.Remove(Etcd)
-	}
-
-	if IP == "" || len(etcdIPs) == 0 {
-		return
-	}
-
-	sv.run(Registry)
-	sv.run(Etcd, fmt.Sprintf("--name=master-%s", IP),
-		fmt.Sprintf("--initial-cluster=%s", initialClusterString(etcdIPs)),
-		fmt.Sprintf("--advertise-client-urls=http://%s:2379", IP),
-		fmt.Sprintf("--listen-peer-urls=http://%s:2380", IP),
-		fmt.Sprintf("--initial-advertise-peer-urls=http://%s:2380", IP),
-		"--listen-client-urls=http://0.0.0.0:2379",
-		"--heartbeat-interval="+etcdHeartbeatInterval,
-		"--initial-cluster-state=new",
-		"--election-timeout="+etcdElectionTimeout)
-	sv.run(Ovsdb, "ovsdb-server")
-
-	if leader {
-		/* XXX: If we fail to boot ovn-northd, we should give up
-		* our leadership somehow.  This ties into the general
-		* problem of monitoring health. */
-		sv.run(Ovnnorthd, "ovn-northd")
-	} else {
-		sv.Remove(Ovnnorthd)
-	}
-
-	sv.SetInit()
-}
-
-func (sv *supervisor) run(name string, args ...string) {
-	isRunning, err := sv.dk.IsRunning(name)
+// run calls out to the Docker client to run the container specified by name.
+func run(name string, args ...string) {
+	isRunning, err := dk.IsRunning(name)
 	if err != nil {
 		log.WithError(err).Warnf("could not check running status of %s.", name)
 		return
@@ -234,22 +103,24 @@ func (sv *supervisor) run(name string, args ...string) {
 	}
 
 	log.Infof("Start Container: %s", name)
-	_, err = sv.dk.Run(ro)
+	_, err = dk.Run(ro)
 	if err != nil {
 		log.WithError(err).Warnf("Failed to run %s.", name)
 	}
 }
 
-func (sv *supervisor) Remove(name string) {
+// Remove removes the docker container specified by name.
+func Remove(name string) {
 	log.WithField("name", name).Info("Removing container")
-	err := sv.dk.Remove(name)
+	err := dk.Remove(name)
 	if err != nil && err != docker.ErrNoSuchContainer {
 		log.WithError(err).Warnf("Failed to remove %s.", name)
 	}
 }
 
-func (sv *supervisor) SetInit() {
-	sv.conn.Txn(db.MinionTable).Run(func(view db.Database) error {
+// SetInit signals to other processes that the supervisor has finshed setup.
+func SetInit() {
+	conn.Txn(db.MinionTable).Run(func(view db.Database) error {
 		self, err := view.MinionSelf()
 		if err == nil {
 			self.SupervisorInit = true
@@ -277,24 +148,6 @@ var execRun = func(name string, arg ...string) error {
 	return exec.Command(name, arg...).Run()
 }
 
-func cfgGatewayImpl(name string, ip net.IPNet) error {
-	link, err := linkByName(name)
-	if err != nil {
-		return fmt.Errorf("no such interface: %s (%s)", name, err)
-	}
-
-	if err := linkSetUp(link); err != nil {
-		return fmt.Errorf("failed to bring up link: %s (%s)", name, err)
-	}
-
-	if err := addrAdd(link, &netlink.Addr{IPNet: &ip}); err != nil {
-		return fmt.Errorf("failed to set address: %s (%s)", name, err)
-	}
-
-	return nil
-}
-
-var cfgGateway = cfgGatewayImpl
 var linkByName = netlink.LinkByName
 var linkSetUp = netlink.LinkSetUp
 var addrAdd = netlink.AddrAdd

--- a/minion/supervisor/supervisor.go
+++ b/minion/supervisor/supervisor.go
@@ -118,18 +118,6 @@ func Remove(name string) {
 	}
 }
 
-// SetInit signals to other processes that the supervisor has finshed setup.
-func SetInit() {
-	conn.Txn(db.MinionTable).Run(func(view db.Database) error {
-		self, err := view.MinionSelf()
-		if err == nil {
-			self.SupervisorInit = true
-			view.Commit(self)
-		}
-		return err
-	})
-}
-
 func initialClusterString(etcdIPs []string) string {
 	var initialCluster []string
 	for _, ip := range etcdIPs {

--- a/minion/supervisor/worker.go
+++ b/minion/supervisor/worker.go
@@ -15,7 +15,6 @@ import (
 
 func runWorker() {
 	setupWorker()
-	SetInit()
 	go runWorkerSystem()
 }
 

--- a/minion/supervisor/worker.go
+++ b/minion/supervisor/worker.go
@@ -52,10 +52,7 @@ func runWorkerSystem() {
 }
 
 func runWorkerOnce() {
-	minion, err := conn.MinionSelf()
-	if err != nil {
-		return
-	}
+	minion := conn.MinionSelf()
 
 	var etcdRow db.Etcd
 	if etcdRows := conn.SelectFromEtcd(nil); len(etcdRows) == 1 {
@@ -85,7 +82,7 @@ func runWorkerOnce() {
 		return
 	}
 
-	err = execRun("ovs-vsctl", "set", "Open_vSwitch", ".",
+	err := execRun("ovs-vsctl", "set", "Open_vSwitch", ".",
 		fmt.Sprintf("external_ids:ovn-remote=\"tcp:%s:6640\"", leaderIP),
 		fmt.Sprintf("external_ids:ovn-encap-ip=%s", IP),
 		fmt.Sprintf("external_ids:ovn-encap-type=\"%s\"", tunnelingProtocol),

--- a/minion/supervisor/worker.go
+++ b/minion/supervisor/worker.go
@@ -1,0 +1,130 @@
+package supervisor
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/quilt/quilt/db"
+	"github.com/quilt/quilt/minion/ipdef"
+	"github.com/quilt/quilt/util"
+	"github.com/vishvananda/netlink"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func runWorker() {
+	setupWorker()
+	SetInit()
+	go runWorkerSystem()
+}
+
+func setupWorker() {
+	run(Ovsdb, "ovsdb-server")
+	run(Ovsvswitchd, "ovs-vswitchd")
+
+	for {
+		err := setupBridge()
+		if err == nil {
+			break
+		}
+		log.WithError(err).Warnf("Failed to exec in %s.", Ovsvswitchd)
+		time.Sleep(5 * time.Second)
+	}
+
+	ip := net.IPNet{IP: ipdef.GatewayIP, Mask: ipdef.QuiltSubnet.Mask}
+	for {
+		err := cfgGateway("quilt-int", ip)
+		if err == nil {
+			break
+		}
+		log.WithError(err).Error("Failed to configure quilt-int.")
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func runWorkerSystem() {
+	loopLog := util.NewEventTimer("Supervisor")
+	for range conn.Trigger(db.MinionTable, db.EtcdTable).C {
+		loopLog.LogStart()
+		runWorkerOnce()
+		loopLog.LogEnd()
+	}
+}
+
+func runWorkerOnce() {
+	minion, err := conn.MinionSelf()
+	if err != nil {
+		return
+	}
+
+	var etcdRow db.Etcd
+	if etcdRows := conn.SelectFromEtcd(nil); len(etcdRows) == 1 {
+		etcdRow = etcdRows[0]
+	}
+
+	etcdIPs := etcdRow.EtcdIPs
+	leaderIP := etcdRow.LeaderIP
+	IP := minion.PrivateIP
+
+	if !util.StrSliceEqual(oldEtcdIPs, etcdIPs) {
+		Remove(Etcd)
+	}
+
+	oldEtcdIPs = etcdIPs
+	oldIP = IP
+
+	run(Etcd, fmt.Sprintf("--initial-cluster=%s", initialClusterString(etcdIPs)),
+		"--heartbeat-interval="+etcdHeartbeatInterval,
+		"--election-timeout="+etcdElectionTimeout,
+		"--proxy=on")
+
+	run(Ovsdb, "ovsdb-server")
+	run(Ovsvswitchd, "ovs-vswitchd")
+
+	if leaderIP == "" || IP == "" {
+		return
+	}
+
+	err = execRun("ovs-vsctl", "set", "Open_vSwitch", ".",
+		fmt.Sprintf("external_ids:ovn-remote=\"tcp:%s:6640\"", leaderIP),
+		fmt.Sprintf("external_ids:ovn-encap-ip=%s", IP),
+		fmt.Sprintf("external_ids:ovn-encap-type=\"%s\"", tunnelingProtocol),
+		fmt.Sprintf("external_ids:api_server=\"http://%s:9000\"", leaderIP),
+		fmt.Sprintf("external_ids:system-id=\"%s\"", IP))
+	if err != nil {
+		log.WithError(err).Warnf("Failed to exec in %s.", Ovsvswitchd)
+		return
+	}
+
+	/* The ovn controller doesn't support reconfiguring ovn-remote mid-run.
+	 * So, we need to restart the container when the leader changes. */
+	Remove(Ovncontroller)
+	run(Ovncontroller, "ovn-controller")
+}
+
+func setupBridge() error {
+	gwMac := ipdef.IPToMac(ipdef.GatewayIP)
+	return execRun("ovs-vsctl", "add-br", "quilt-int",
+		"--", "set", "bridge", "quilt-int", "fail_mode=secure",
+		fmt.Sprintf("other_config:hwaddr=\"%s\"", gwMac))
+}
+
+func cfgGatewayImpl(name string, ip net.IPNet) error {
+	link, err := linkByName(name)
+	if err != nil {
+		return fmt.Errorf("no such interface: %s (%s)", name, err)
+	}
+
+	if err := linkSetUp(link); err != nil {
+		return fmt.Errorf("failed to bring up link: %s (%s)", name, err)
+	}
+
+	if err := addrAdd(link, &netlink.Addr{IPNet: &ip}); err != nil {
+		return fmt.Errorf("failed to set address: %s (%s)", name, err)
+	}
+
+	return nil
+}
+
+var cfgGateway = cfgGatewayImpl

--- a/minion/supervisor/worker_test.go
+++ b/minion/supervisor/worker_test.go
@@ -1,0 +1,176 @@
+package supervisor
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/quilt/quilt/db"
+	"github.com/quilt/quilt/minion/ipdef"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+)
+
+func TestWorker(t *testing.T) {
+	ctx := initTest(db.Worker)
+	ip := "1.2.3.4"
+	etcdIPs := []string{ip}
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Worker
+		m.PrivateIP = ip
+		e.EtcdIPs = etcdIPs
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp := map[string][]string{
+		Etcd:        etcdArgsWorker(etcdIPs),
+		Ovsdb:       {"ovsdb-server"},
+		Ovsvswitchd: {"ovs-vswitchd"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+	if len(ctx.execs) > 0 {
+		t.Errorf("exec = %s; want <empty>", spew.Sdump(ctx.execs))
+	}
+
+	leaderIP := "5.6.7.8"
+	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
+		m, _ := view.MinionSelf()
+		e := view.SelectFromEtcd(nil)[0]
+		m.Role = db.Worker
+		m.PrivateIP = ip
+		e.EtcdIPs = etcdIPs
+		e.LeaderIP = leaderIP
+		view.Commit(m)
+		view.Commit(e)
+		return nil
+	})
+	ctx.run()
+
+	exp = map[string][]string{
+		Etcd:          etcdArgsWorker(etcdIPs),
+		Ovsdb:         {"ovsdb-server"},
+		Ovncontroller: {"ovn-controller"},
+		Ovsvswitchd:   {"ovs-vswitchd"},
+	}
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+
+	execExp := ovsExecArgs(ip, leaderIP)
+	if !reflect.DeepEqual(ctx.execs, execExp) {
+		t.Errorf("execs = %s\n\nwant %s", spew.Sdump(ctx.execs),
+			spew.Sdump(execExp))
+	}
+}
+
+func TestSetupWorker(t *testing.T) {
+	ctx := initTest(db.Worker)
+
+	setupWorker()
+
+	exp := map[string][]string{
+		Ovsdb:       {"ovsdb-server"},
+		Ovsvswitchd: {"ovs-vswitchd"},
+	}
+
+	if !reflect.DeepEqual(ctx.fd.running(), exp) {
+		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
+			spew.Sdump(exp))
+	}
+
+	execExp := setupArgs()
+	if !reflect.DeepEqual(ctx.execs, execExp) {
+		t.Errorf("execs = %s\n\nwant %s", spew.Sdump(ctx.execs),
+			spew.Sdump(execExp))
+	}
+}
+
+func TestCfgGateway(t *testing.T) {
+	linkByName = func(name string) (netlink.Link, error) {
+		if name == "quilt-int" {
+			return &netlink.Device{}, nil
+		}
+		return nil, errors.New("linkByName")
+	}
+
+	linkSetUp = func(link netlink.Link) error {
+		return errors.New("linkSetUp")
+	}
+
+	addrAdd = func(link netlink.Link, addr *netlink.Addr) error {
+		return errors.New("addrAdd")
+	}
+
+	ip := net.IPNet{IP: ipdef.GatewayIP, Mask: ipdef.QuiltSubnet.Mask}
+
+	err := cfgGatewayImpl("bogus", ip)
+	assert.EqualError(t, err, "no such interface: bogus (linkByName)")
+
+	err = cfgGatewayImpl("quilt-int", ip)
+	assert.EqualError(t, err, "failed to bring up link: quilt-int (linkSetUp)")
+
+	var up bool
+	linkSetUp = func(link netlink.Link) error {
+		up = true
+		return nil
+	}
+
+	up = false
+	err = cfgGatewayImpl("quilt-int", ip)
+	assert.EqualError(t, err, "failed to set address: quilt-int (addrAdd)")
+	assert.True(t, up)
+
+	var setAddr net.IPNet
+	addrAdd = func(link netlink.Link, addr *netlink.Addr) error {
+		setAddr = *addr.IPNet
+		return nil
+	}
+
+	up = false
+	err = cfgGatewayImpl("quilt-int", ip)
+	assert.NoError(t, err)
+	assert.True(t, up)
+	assert.Equal(t, setAddr, ip)
+}
+
+func setupArgs() [][]string {
+	vsctl := []string{
+		"ovs-vsctl", "add-br", "quilt-int",
+		"--", "set", "bridge", "quilt-int", "fail_mode=secure",
+		"other_config:hwaddr=\"02:00:0a:00:00:01\"",
+	}
+	gateway := []string{"cfgGateway", "10.0.0.1/8"}
+	return [][]string{vsctl, gateway}
+}
+
+func ovsExecArgs(ip, leader string) [][]string {
+	vsctl := []string{"ovs-vsctl", "set", "Open_vSwitch", ".",
+		fmt.Sprintf("external_ids:ovn-remote=\"tcp:%s:6640\"", leader),
+		fmt.Sprintf("external_ids:ovn-encap-ip=%s", ip),
+		"external_ids:ovn-encap-type=\"stt\"",
+		fmt.Sprintf("external_ids:api_server=\"http://%s:9000\"", leader),
+		fmt.Sprintf("external_ids:system-id=\"%s\"", ip),
+	}
+	return [][]string{vsctl}
+}
+
+func etcdArgsWorker(etcdIPs []string) []string {
+	return []string{
+		fmt.Sprintf("--initial-cluster=%s", initialClusterString(etcdIPs)),
+		"--heartbeat-interval=500",
+		"--election-timeout=5000",
+		"--proxy=on",
+	}
+}

--- a/minion/supervisor/worker_test.go
+++ b/minion/supervisor/worker_test.go
@@ -19,7 +19,7 @@ func TestWorker(t *testing.T) {
 	ip := "1.2.3.4"
 	etcdIPs := []string{ip}
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Worker
 		m.PrivateIP = ip
@@ -45,7 +45,7 @@ func TestWorker(t *testing.T) {
 
 	leaderIP := "5.6.7.8"
 	ctx.conn.Txn(db.AllTables...).Run(func(view db.Database) error {
-		m, _ := view.MinionSelf()
+		m := view.MinionSelf()
 		e := view.SelectFromEtcd(nil)[0]
 		m.Role = db.Worker
 		m.PrivateIP = ip

--- a/quiltctl/command/minion.go
+++ b/quiltctl/command/minion.go
@@ -1,16 +1,35 @@
 package command
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"os"
 
+	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/minion"
 )
 
 // Minion contains the options for running the Quilt minion.
-type Minion struct{}
+type Minion struct {
+	role string
+}
+
+// NewMinionCommand creates a new Minion command instance.
+func NewMinionCommand() *Minion {
+	return &Minion{}
+}
 
 // InstallFlags sets up parsing for command line flags.
 func (mCmd *Minion) InstallFlags(flags *flag.FlagSet) {
+	flags.StringVar(&mCmd.role, "role", "", "the role of this quilt minion")
+
+	flags.Usage = func() {
+		fmt.Println("usage: quilt minion [-role=<role>]")
+		fmt.Println("`role` defines the role of the quilt minion to run, e.g. " +
+			"`Master` or `Worker`.")
+		flags.PrintDefaults()
+	}
 }
 
 // Parse parses the command line arguments for the minion command.
@@ -20,6 +39,22 @@ func (mCmd *Minion) Parse(args []string) error {
 
 // Run starts the minion.
 func (mCmd *Minion) Run() int {
-	minion.Run()
+	if err := mCmd.run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
 	return 0
+}
+
+func (mCmd *Minion) run() error {
+
+	role, err := db.ParseRole(mCmd.role)
+
+	if err != nil || role == db.None {
+		return errors.New("no or improper role specified")
+	}
+
+	minion.Run(role)
+
+	return nil
 }

--- a/quiltctl/command/minion_test.go
+++ b/quiltctl/command/minion_test.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinionFlags(t *testing.T) {
+	t.Parallel()
+
+	expRole := "Worker"
+
+	cmd := NewMinionCommand()
+	err := parseHelper(cmd, []string{"-role", expRole})
+
+	assert.NoError(t, err)
+	assert.Equal(t, expRole, cmd.role)
+}
+
+func TestMinionFailure(t *testing.T) {
+	t.Parallel()
+
+	badRole := "Derper"
+	cmd := NewMinionCommand()
+	roleError := errors.New("no or improper role specified")
+
+	cmd.role = badRole
+
+	assert.Error(t, roleError, cmd.run())
+	assert.Equal(t, 1, cmd.Run())
+
+	cmd = NewMinionCommand()
+	noRoleError := errors.New("no or improper role specified")
+
+	assert.Error(t, noRoleError, cmd.run())
+	assert.Equal(t, 1, cmd.Run())
+}

--- a/quiltctl/quiltctl.go
+++ b/quiltctl/quiltctl.go
@@ -16,7 +16,7 @@ var commands = map[string]command.SubCommand{
 	"inspect":    &command.Inspect{},
 	"logs":       command.NewLogCommand(),
 	"machines":   command.NewMachineCommand(),
-	"minion":     &command.Minion{},
+	"minion":     command.NewMinionCommand(),
 	"ps":         command.NewPsCommand(),
 	"run":        command.NewRunCommand(),
 	"ssh":        command.NewSSHCommand(),


### PR DESCRIPTION
This patch aims to fix minion role at boot time through the cloud cfg, in order to more easily simplify the minion modules (e.g. supervisor, network, etc.)

Some high level highlights:

- The `foreman` is no longer able to change a minion's role
- role has been added to the join in `cluster`. `cluster` gets the role for the `machine.Machine`s it gets from the cloud providers by asking the `foreman`
- role is passed down through cloud cfg
- minions accept role from cloud cfg (via modifying the `quilt minion` command) and use it instead of getting role from protobuf