### PR TITLE
quiltctl: Added 'quilt switch' command

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -48,6 +48,9 @@ type Client interface {
 	// QueryClusters retrieves cluster information tracked by the Quilt daemon.
 	QueryClusters() ([]db.Cluster, error)
 
+	// QueryMinions retrieves the minions tracked by the Quilt daemon.
+	QueryMinions() ([]db.Minion, error)
+
 	// Deploy makes a request to the Quilt daemon to deploy the given deployment.
 	Deploy(deployment string) error
 
@@ -144,6 +147,12 @@ func query(pbClient pb.APIClient, table db.TableType) (interface{}, error) {
 			return nil, err
 		}
 		return clusters, nil
+	case db.MinionTable:
+		var minions []db.Minion
+		if err := json.Unmarshal(replyBytes, &minions); err != nil {
+			return nil, err
+		}
+		return minions, nil
 	default:
 		panic(fmt.Sprintf("unsupported table type: %s", table))
 	}
@@ -162,6 +171,16 @@ func (c clientImpl) QueryMachines() ([]db.Machine, error) {
 	}
 
 	return rows.([]db.Machine), nil
+}
+
+// QueryMinions retrieves the minions tracked by the Quilt daemon.
+func (c clientImpl) QueryMinions() ([]db.Minion, error) {
+	rows, err := query(c.pbClient, db.MinionTable)
+	if err != nil {
+		return nil, err
+	}
+
+	return rows.([]db.Minion), nil
 }
 
 // QueryContainers retrieves the containers tracked by the Quilt daemon.

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -29,6 +29,37 @@ func (c mockAPIClient) Deploy(ctx context.Context, in *pb.DeployRequest,
 	return &pb.DeployReply{}, nil
 }
 
+func TestUnmarshalMinion(t *testing.T) {
+	t.Parallel()
+
+	apiClient := mockAPIClient{
+		mockResponse: `[{"Role":"Master","Spec":"testSpec","Provider":"Amazon",` +
+			`"Region":"","Size":"size","DiskSize":0,"SSHKeys":null,` +
+			`"CloudID":"","PrivateIP":"9.9.9.9"}]`,
+	}
+	c := clientImpl{pbClient: apiClient}
+	res, err := c.QueryMinions()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+		return
+	}
+
+	exp := []db.Minion{
+		{
+			Role:      "Master",
+			Spec:      "testSpec",
+			Provider:  "Amazon",
+			Size:      "size",
+			PrivateIP: "9.9.9.9",
+		},
+	}
+
+	if !reflect.DeepEqual(exp, res) {
+		t.Errorf("Bad unmarshalling of minions: expected %v, got %v.",
+			exp, res)
+	}
+}
+
 func TestUnmarshalMachine(t *testing.T) {
 	t.Parallel()
 

--- a/api/client/mocks/client.go
+++ b/api/client/mocks/client.go
@@ -10,11 +10,12 @@ type Client struct {
 	ContainerReturn []db.Container
 	EtcdReturn      []db.Etcd
 	ClusterReturn   []db.Cluster
+	MinionReturn    []db.Minion
 	HostReturn      string
 	DeployArg       string
 
 	MachineErr, ContainerErr, EtcdErr, ClusterErr, HostErr error
-	DeployErr, ConnectionErr                               error
+	DeployErr, ConnectionErr, MinionErr                    error
 }
 
 // QueryMachines retrieves the machines tracked by the Quilt daemon.
@@ -48,6 +49,15 @@ func (c *Client) QueryConnections() ([]db.Connection, error) {
 		return nil, c.ConnectionErr
 	}
 	return nil, nil
+}
+
+// QueryMinions retrieves the connection information tracked by the
+// Quilt daemon.
+func (c *Client) QueryMinions() ([]db.Minion, error) {
+	if c.MinionErr != nil {
+		return nil, c.MinionErr
+	}
+	return c.MinionReturn, nil
 }
 
 // QueryLabels retrieves the label information tracked by the Quilt daemon.

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -78,6 +78,8 @@ func (s server) Query(cts context.Context, query *pb.DBQuery) (*pb.QueryReply, e
 		rows = s.conn.SelectFromLabel(nil)
 	case db.ClusterTable:
 		rows = s.conn.SelectFromCluster(nil)
+	case db.MinionTable:
+		rows = s.conn.SelectFromMinion(nil)
 	default:
 		return nil, fmt.Errorf("unrecognized table: %s", query.Table)
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -428,6 +428,13 @@ func (clst cluster) get() ([]machine.Machine, error) {
 	return cloudMachines, nil
 }
 
+// GetMachines gets the list of machines associated with the namespace
+func GetMachines(namespace string) ([]machine.Machine, error) {
+	c := newCluster(db.Conn{}, namespace)
+	machines, err := c.get()
+	return machines, err
+}
+
 func groupBy(machines []machine.Machine) map[instance][]machine.Machine {
 	machineMap := map[instance][]machine.Machine{}
 	for _, m := range machines {

--- a/db/minion.go
+++ b/db/minion.go
@@ -8,12 +8,12 @@ type Minion struct {
 	ID int `json:"-"`
 
 	Self           bool   `json:"-"`
-	Spec           string `json:"-" rowStringer:"omit"`
 	AuthorizedKeys string `json:"-" rowStringer:"omit"`
 	SupervisorInit bool   `json:"-"`
 
 	// Below fields are included in the JSON encoding.
 	Role       Role
+	Spec       string `rowStringer:"omit"`
 	PrivateIP  string
 	Provider   string
 	Size       string

--- a/minion/etcd/minion_test.go
+++ b/minion/etcd/minion_test.go
@@ -29,6 +29,7 @@ func TestWriteMinion(t *testing.T) {
 		m.Self = true
 		m.Role = db.Master
 		m.Provider = "Amazon"
+		m.Spec = "testSpec"
 		m.Size = "Big"
 		m.Region = "Somewhere"
 		view.Commit(m)
@@ -52,6 +53,7 @@ func TestWriteMinion(t *testing.T) {
 
 	expVal := `{
     "Role": "Master",
+    "Spec": "testSpec",
     "PrivateIP": "1.2.3.4",
     "Provider": "Amazon",
     "Size": "Big",

--- a/quiltctl/command/switch.go
+++ b/quiltctl/command/switch.go
@@ -1,0 +1,113 @@
+package command
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/quilt/quilt/api"
+	"github.com/quilt/quilt/api/client"
+	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/cluster"
+	"github.com/quilt/quilt/cluster/machine"
+)
+
+// Switch contains the options for switching namespaces
+type Switch struct {
+	namespace    string
+	common       *commonFlags
+	clientGetter client.Getter
+}
+
+// NewSwitchCommand creates an instance of the Switch command.
+func NewSwitchCommand() *Switch {
+	return &Switch{
+		common:       &commonFlags{},
+		clientGetter: getter.New(),
+	}
+}
+
+// For mock testing
+var machineGetter = cluster.GetMachines
+
+// InstallFlags sets up parsing for command line flags.
+func (sCmd *Switch) InstallFlags(flags *flag.FlagSet) {
+	sCmd.common.InstallFlags(flags)
+
+	flags.Usage = func() {
+		fmt.Println("usage: quilt switch <namespace>")
+		fmt.Printf("`switch` switches to a different namespace\n")
+		flags.PrintDefaults()
+	}
+}
+
+// Parse parses the command line arguments for the switch command.
+func (sCmd *Switch) Parse(args []string) error {
+	if len(args) == 0 {
+		return errors.New("no namespace specified")
+	}
+	sCmd.namespace = args[0]
+	return nil
+}
+
+// Run switches the current cluster to the specified namespace.
+func (sCmd *Switch) Run() int {
+	log.Info("Switching to namespace " + sCmd.namespace)
+
+	machines, err := machineGetter(sCmd.namespace)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+	if len(machines) < 1 {
+		log.Error("no cluster running with namespace " + sCmd.namespace)
+		return 1
+	}
+
+	spec, err := sCmd.getSpec(machines)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+
+	c, err := sCmd.clientGetter.Client(sCmd.common.host)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+	defer c.Close()
+
+	err = c.Deploy(spec)
+	if err != nil {
+		log.WithError(err).Error("error while starting run.")
+		return 1
+	}
+	log.Info("Successfully deployed spec")
+	return 0
+}
+
+// getSpec attempts to retrieve the spec from the machines in the cluster
+func (sCmd Switch) getSpec(machines []machine.Machine) (string, error) {
+	for _, machine := range machines {
+		machineClient, err := sCmd.clientGetter.Client(
+			api.RemoteAddress(machine.PublicIP))
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		minions, err := machineClient.QueryMinions()
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		for _, minion := range minions {
+			if minion.Spec != "" {
+				return minion.Spec, nil
+			}
+		}
+	}
+	return "", errors.New("none of the machines have a valid spec")
+}

--- a/quiltctl/command/switch_test.go
+++ b/quiltctl/command/switch_test.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"errors"
+	"testing"
+
+	clientMock "github.com/quilt/quilt/api/client/mocks"
+	"github.com/quilt/quilt/cluster/machine"
+	"github.com/quilt/quilt/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRetrieveSpec(t *testing.T) {
+	t.Parallel()
+
+	mockGetter := new(clientMock.Getter)
+	c := &clientMock.Client{}
+	mockGetter.On("Client", mock.Anything).Return(c, nil)
+
+	c.MinionReturn = []db.Minion{
+		{
+			Spec: `testSpec`,
+		},
+	}
+
+	sCmd := NewSwitchCommand()
+	sCmd.clientGetter = mockGetter
+
+	// testMachines must be non-empty for switch to attempt retrieving spec
+	testMachines := []machine.Machine{{}}
+	machineGetter = func(namespace string) ([]machine.Machine, error) {
+		return testMachines, nil
+	}
+
+	spec, err := sCmd.getSpec(testMachines)
+	assert.NoError(t, err)
+	assert.Equal(t, spec, `testSpec`)
+
+	exitCode := sCmd.Run()
+	assert.Equal(t, exitCode, 0)
+	assert.Equal(t, c.DeployArg, `testSpec`)
+}
+
+func TestNoMachines(t *testing.T) {
+	t.Parallel()
+
+	mockGetter := new(clientMock.Getter)
+	c := &clientMock.Client{}
+	mockGetter.On("Client", mock.Anything).Return(c, nil)
+
+	sCmd := NewSwitchCommand()
+	sCmd.clientGetter = mockGetter
+	testMachines := []machine.Machine{}
+	machineGetter = func(namespace string) ([]machine.Machine, error) {
+		return testMachines, nil
+	}
+
+	exitCode := sCmd.Run()
+	assert.Equal(t, exitCode, 1)
+
+	spec, err := sCmd.getSpec(testMachines)
+	assert.Equal(t, spec, "")
+	assert.Error(t, err, "none of the machines have a valid spec")
+}
+
+func TestBadClient(t *testing.T) {
+	t.Parallel()
+
+	mockGetter := new(clientMock.Getter)
+	c := &clientMock.Client{}
+	mockGetter.On("Client", mock.Anything).Return(c,
+		errors.New("error getting client"))
+
+	sCmd := NewSwitchCommand()
+	sCmd.clientGetter = mockGetter
+	testMachines := []machine.Machine{{}}
+	machineGetter = func(namespace string) ([]machine.Machine, error) {
+		return testMachines, nil
+	}
+
+	exitCode := sCmd.Run()
+	assert.Equal(t, exitCode, 1)
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	checkSwitchParsing(t, []string{}, "", errors.New("no namespace specified"))
+	checkSwitchParsing(t, []string{"someNamespace"}, "someNamespace", nil)
+}
+
+func checkSwitchParsing(t *testing.T, args []string, expNamespace string, expErr error) {
+	sCmd := NewSwitchCommand()
+	err := parseHelper(sCmd, args)
+
+	assert.Equal(t, expErr, err)
+	assert.Equal(t, expNamespace, sCmd.namespace)
+}

--- a/quiltctl/quiltctl.go
+++ b/quiltctl/quiltctl.go
@@ -21,6 +21,7 @@ var commands = map[string]command.SubCommand{
 	"run":        command.NewRunCommand(),
 	"ssh":        command.NewSSHCommand(),
 	"stop":       command.NewStopCommand(),
+	"switch":     command.NewSwitchCommand(),
 }
 
 // Run parses and runs the quiltctl subcommand given the command line arguments.


### PR DESCRIPTION
'quilt switch <namespace>' provides the ability to switch to another
namespace without manually calling 'quilt run <spec>' again.