### PR TITLE
quiltctl: Show a reasonable error on trying to use an encrypted key

### DIFF
--- a/quiltctl/ssh/native_test.go
+++ b/quiltctl/ssh/native_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quilt/quilt/util"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -35,7 +37,7 @@ func TestDefaultKeys(t *testing.T) {
 	}
 
 	for _, key := range []string{"id_rsa", "id_dsa", "ignored"} {
-		if err := writeRandomKey(filepath.Join(sshDir, key)); err != nil {
+		if err := writeRandomKey(filepath.Join(sshDir, key), false); err != nil {
 			t.Errorf("Failed to write key: %q", err.Error())
 			return
 		}
@@ -47,10 +49,58 @@ func TestDefaultKeys(t *testing.T) {
 	}
 }
 
-func writeRandomKey(path string) error {
+func TestEncryptedKey(t *testing.T) {
+	util.AppFs = afero.NewMemMapFs()
+
+	dir, err := homedir.Dir()
+	if err != nil {
+		t.Errorf("Failed to get homedir: %q", err.Error())
+		return
+	}
+
+	sshDir := filepath.Join(dir, ".ssh")
+	if err := util.AppFs.MkdirAll(sshDir, 0600); err != nil {
+		t.Errorf("Failed to create SSH directory: %q", err.Error())
+		return
+	}
+
+	keyPath := filepath.Join(sshDir, "key")
+	if err := writeRandomKey(keyPath, true); err != nil {
+		t.Errorf("Failed to write key: %q", err.Error())
+		return
+	}
+
+	_, err = signerFromFile(keyPath)
+
+	assert.Error(t, err, "ssh: password protected keys are "+
+		"not supported, try adding the key to ssh-agent first using "+
+		"`ssh-add`")
+}
+
+func writeRandomKey(path string, encrypt bool) error {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return err
+	}
+
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+
+	if encrypt {
+		// Generate a random passphrase to encrypt the key
+		passphrase := make([]byte, 10)
+		_, err := rand.Read(passphrase)
+		if err != nil {
+			return err
+		}
+
+		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes,
+			passphrase, x509.PEMCipherAES256)
+		if err != nil {
+			return err
+		}
 	}
 
 	f, err := util.AppFs.Create(path)
@@ -58,8 +108,6 @@ func writeRandomKey(path string) error {
 		return err
 	}
 	defer f.Close()
-	return pem.Encode(f, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
+
+	return pem.Encode(f, block)
 }


### PR DESCRIPTION
Previously, using `quilt ssh` or `quilt logs` with an encrypted private
key would show the error `asn1: structure error: length too large`,
which made the actual issue unclear. We now tell the user that
encrypted keys are unsupported and recommend they add the key to
`ssh-agent`.