### PR TITLE
supervisor: Fix registry container on Master

### DIFF
--- a/minion/supervisor/master.go
+++ b/minion/supervisor/master.go
@@ -9,6 +9,7 @@ import (
 
 func runMaster() {
 	run(Ovsdb, "ovsdb-server")
+	run(Registry)
 	go runMasterSystem()
 }
 
@@ -53,7 +54,9 @@ func runMasterOnce() {
 		"--heartbeat-interval="+etcdHeartbeatInterval,
 		"--initial-cluster-state=new",
 		"--election-timeout="+etcdElectionTimeout)
+
 	run(Ovsdb, "ovsdb-server")
+	run(Registry)
 
 	if leader {
 		/* XXX: If we fail to boot ovn-northd, we should give up

--- a/minion/supervisor/master_test.go
+++ b/minion/supervisor/master_test.go
@@ -57,8 +57,9 @@ func TestMaster(t *testing.T) {
 	ctx.run()
 
 	exp := map[string][]string{
-		Etcd:  etcdArgsMaster(ip, etcdIPs),
-		Ovsdb: {"ovsdb-server"},
+		Etcd:     etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:    {"ovsdb-server"},
+		Registry: nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -89,6 +90,7 @@ func TestMaster(t *testing.T) {
 		Etcd:      etcdArgsMaster(ip, etcdIPs),
 		Ovsdb:     {"ovsdb-server"},
 		Ovnnorthd: {"ovn-northd"},
+		Registry:  nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -108,8 +110,9 @@ func TestMaster(t *testing.T) {
 	ctx.run()
 
 	exp = map[string][]string{
-		Etcd:  etcdArgsMaster(ip, etcdIPs),
-		Ovsdb: {"ovsdb-server"},
+		Etcd:     etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:    {"ovsdb-server"},
+		Registry: nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -137,8 +140,9 @@ func TestEtcdAdd(t *testing.T) {
 	ctx.run()
 
 	exp := map[string][]string{
-		Etcd:  etcdArgsMaster(ip, etcdIPs),
-		Ovsdb: {"ovsdb-server"},
+		Etcd:     etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:    {"ovsdb-server"},
+		Registry: nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -159,8 +163,9 @@ func TestEtcdAdd(t *testing.T) {
 	ctx.run()
 
 	exp = map[string][]string{
-		Etcd:  etcdArgsMaster(ip, etcdIPs),
-		Ovsdb: {"ovsdb-server"},
+		Etcd:     etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:    {"ovsdb-server"},
+		Registry: nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -185,8 +190,9 @@ func TestEtcdRemove(t *testing.T) {
 	ctx.run()
 
 	exp := map[string][]string{
-		Etcd:  etcdArgsMaster(ip, etcdIPs),
-		Ovsdb: {"ovsdb-server"},
+		Etcd:     etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:    {"ovsdb-server"},
+		Registry: nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -207,8 +213,9 @@ func TestEtcdRemove(t *testing.T) {
 	ctx.run()
 
 	exp = map[string][]string{
-		Etcd:  etcdArgsMaster(ip, etcdIPs),
-		Ovsdb: {"ovsdb-server"},
+		Etcd:     etcdArgsMaster(ip, etcdIPs),
+		Ovsdb:    {"ovsdb-server"},
+		Registry: nil,
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),


### PR DESCRIPTION
A previous patch did not run the registry container on Masters, causing
the Mean integration test and the build dockerfile test to fail.

This patch corrects the minion behavior to run the registry properly.