### PR TITLE
quiltctl: Add help message for ssh commands that need to allocate pty

### DIFF
--- a/quiltctl/command/ssh.go
+++ b/quiltctl/command/ssh.go
@@ -145,6 +145,8 @@ func (sCmd SSH) Run() int {
 		if exitErr, ok := err.(exitError); ok {
 			log.WithError(err).Debug(
 				"SSH command returned a nonzero exit code")
+			fmt.Println("Do you need to allocate a pseudo-TTY? " +
+				"Use quilt ssh -t")
 			return exitErr.ExitStatus()
 		}
 


### PR DESCRIPTION
`quilt ssh` can fail with a tty error if a pty is not allocated for commands that need one.

Unfortunately, there is no good way to catch this command. Printing out the error returned from the native SSH client gives `Process exited with status 1` (lol)

So, this just adds a small help message in `quilt ssh -h` for users to be able to read.