### PR TITLE
build: Build windows executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ _testmain.go
 *.prof
 
 quilt
+quilt.exe
 
 *.cov
 *.cov.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
     - govendor test -i +local
-    - make -j 2 lint format-check coverage check-specs docker-build-quilt
+    - make -j 2 lint format-check coverage check-specs docker-build-quilt windows
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ clean:
 	rm -f *.cov.coverprofile cluster/*.cov.coverprofile minion/*.cov.coverprofile
 	rm -f *.cov.html cluster/*.cov.html minion/*.cov.html
 
+windows:
+	cd -P . && GOOS=windows GOARCH=386 go build .
+
 COV_SKIP= /api/client/mocks \
 	  /api/pb \
 	  /cluster/provider/mocks \

--- a/api/common.go
+++ b/api/common.go
@@ -8,7 +8,7 @@ import (
 )
 
 // DefaultSocket is the socket the Quilt daemon listens on by default.
-const DefaultSocket = "unix:///tmp/quilt.sock"
+var DefaultSocket = "unix:///tmp/quilt.sock"
 
 // DefaultRemotePort is the port remote Quilt daemons (the minion) listen on by default.
 const DefaultRemotePort = 9000

--- a/api/common_windows.go
+++ b/api/common_windows.go
@@ -1,0 +1,6 @@
+package api
+
+func init() {
+	// Windows doesn't support unix sockets, so we use a TCP socket instead.
+	DefaultSocket = "tcp://127.0.0.1:9001"
+}

--- a/minion/run.go
+++ b/minion/run.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package minion
 
 import (

--- a/quiltctl/command/minion.go
+++ b/quiltctl/command/minion.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package command
 
 import (

--- a/quiltctl/quiltctl.go
+++ b/quiltctl/quiltctl.go
@@ -9,12 +9,12 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+// Note the `minion` command is in quiltclt_posix.go as it only runs on posix systems.
 var commands = map[string]command.SubCommand{
 	"daemon":  command.NewDaemonCommand(),
 	"get":     &command.Get{},
 	"inspect": &command.Inspect{},
 	"logs":    command.NewLogCommand(),
-	"minion":  command.NewMinionCommand(),
 	"ps":      command.NewPsCommand(),
 	"run":     command.NewRunCommand(),
 	"ssh":     command.NewSSHCommand(),

--- a/quiltctl/quiltctl_posix.go
+++ b/quiltctl/quiltctl_posix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package quiltctl
+
+import "github.com/quilt/quilt/quiltctl/command"
+
+func init() {
+	commands["minion"] = command.NewMinionCommand()
+}

--- a/quiltctl/ssh/native.go
+++ b/quiltctl/ssh/native.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/quilt/quilt/util"
 
@@ -170,7 +169,7 @@ func (p *pty) Request() error {
 		return err
 	}
 
-	signal.Notify(p.resizeSignal, syscall.SIGWINCH)
+	setupResizeSignal(p.resizeSignal)
 	go p.monitorWindowSize()
 	return nil
 }

--- a/quiltctl/ssh/resize.go
+++ b/quiltctl/ssh/resize.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package ssh
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func setupResizeSignal(sig chan os.Signal) {
+	signal.Notify(sig, syscall.SIGWINCH)
+}

--- a/quiltctl/ssh/resize_windows.go
+++ b/quiltctl/ssh/resize_windows.go
@@ -1,0 +1,7 @@
+package ssh
+
+import "os"
+
+func setupResizeSignal(sig chan os.Signal) {
+	// Unimplemented
+}


### PR DESCRIPTION
We hope to allow quilt to be used from windows desktops.  In service
of that goal, this patch supports cross-compiling the binary for
windows.  The resulting binary hasn't been tested, and may not work.