### PR TITLE
travis: Push master branch as latest tag on docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ after_success:
     - bash <(curl -s https://codecov.io/bash)
     - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
           docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+          if [ "$TRAVIS_BRANCH" == "master" ]; then
+              docker push quilt/quilt:latest;
+          fi
           docker tag quilt/quilt quilt/quilt:$TRAVIS_BRANCH;
           docker push quilt/quilt:$TRAVIS_BRANCH;
       fi


### PR DESCRIPTION
By convention docker containers have a "latest" (i.e. default) build
that needs to be updated by the build system.