### PR TITLE
cluster: Remove "v" from docker hub tag versions

### DIFF
--- a/cluster/cloudcfg/cloudcfg.go
+++ b/cluster/cloudcfg/cloudcfg.go
@@ -2,6 +2,7 @@ package cloudcfg
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -21,11 +22,7 @@ var ver = version.Version
 func Ubuntu(keys []string, role db.Role) string {
 	t := template.Must(template.New("cloudConfig").Parse(cfgTemplate))
 
-	img := quiltImage + ":"
-	if ver != "master" {
-		img += "v"
-	}
-	img += ver
+	img := fmt.Sprintf("%s:%s", quiltImage, ver)
 
 	var cloudConfigBytes bytes.Buffer
 	err := t.Execute(&cloudConfigBytes, struct {

--- a/cluster/cloudcfg/cloudcfg_test.go
+++ b/cluster/cloudcfg/cloudcfg_test.go
@@ -19,7 +19,7 @@ func TestCloudConfig(t *testing.T) {
 
 	ver = "1.2.3"
 	res = Ubuntu([]string{"a", "b"}, db.Worker)
-	exp = "(quilt/quilt:v1.2.3) (a\nb) (xenial) (Worker)"
+	exp = "(quilt/quilt:1.2.3) (a\nb) (xenial) (Worker)"
 	if res != exp {
 		t.Errorf("res: %s\nexp: %s", res, exp)
 	}


### PR DESCRIPTION
Previous patches assumed we would tag our containers with a v followed
by the version number.  For example `quilt/quilt:v1.2.3` would be
version 1.2.3 of the quilt container on docker hub.

Unfortunately, git really hates it when branches and tags have the
same version number.  Since this v1.2.3 syntax is standard for tags,
and the docker hub build is generated from the branch name, this patch
drops the v from the docker hub tag number.  This allows us to name
our branches 1.2.3 and our tags v1.2.3 thus avoiding the git
confusion.