### PR TITLE
supervisor: Remove ineffectual assignment in worker

### DIFF
--- a/minion/supervisor/worker.go
+++ b/minion/supervisor/worker.go
@@ -69,7 +69,6 @@ func runWorkerOnce() {
 	}
 
 	oldEtcdIPs = etcdIPs
-	oldIP = IP
 
 	run(images.Etcd,
 		fmt.Sprintf("--initial-cluster=%s", initialClusterString(etcdIPs)),


### PR DESCRIPTION
A previous patch inserted an ineffectual assignment in worker.go to
keep track of the previous PrivateIP for the worker minion. This value
is not used in running the worker minion, so the assignment was removed.