### PR TITLE
docs: Remove broken link to Stitch.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -156,8 +156,7 @@ Machines in the deployment.
 ## Next Steps: Downloading Other Specs
 You can download specs into your `QUILT_PATH` by executing
 `quilt get <IMPORT_PATH>`, where `<IMPORT_PATH>` is a path to a repository
-containing specs (e.g. `github.com/quilt/nginx`). You can read more about this
-functionality [here](https://github.com/quilt/quilt/blob/master/docs/Stitch.md#quilt_path).
+containing specs (e.g. `github.com/quilt/nginx`).
 
 ## Next Steps: Writing your own Quilt Spec
 


### PR DESCRIPTION
Commit 796336a6 (docs: Remove Stitch documentation for Lisp) removed
Stitch.md because it was falling severely out of date.  This caused a
link in GettingStarted.md to be broken.  This patch solves the issue
by removing the offending link.