### PR TITLE
Vagrant

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -123,9 +123,9 @@ func (s server) Deploy(cts context.Context, deployReq *pb.DeployRequest) (
 	// XXX: Remove this error when the Vagrant provider is done.
 	for _, machine := range stitch.Machines {
 		if machine.Provider == db.Vagrant {
-			err = errors.New("The Vagrant provider is in development." +
-				" The stitch will continue to run, but" +
-				" probably won't work correctly.")
+			err = errors.New("The Vagrant provider is still in development." +
+				" The blueprint will continue to run, but" +
+				" there may be some errors.")
 			return &pb.DeployReply{}, err
 		}
 	}

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -160,9 +160,9 @@ func TestVagrantDeployment(t *testing.T) {
 		"Role":"Worker",
 		"Size":"m4.large"
 	}]}`
-	vagrantErrMsg := "The Vagrant provider is in development." +
-		" The stitch will continue to run, but" +
-		" probably won't work correctly."
+	vagrantErrMsg := "The Vagrant provider is still in development." +
+		" The blueprint will continue to run, but" +
+		" there may be some errors."
 
 	_, err := s.Deploy(context.Background(),
 		&pb.DeployRequest{Deployment: vagrantDeployment})

--- a/cluster/vagrant/api.go
+++ b/cluster/vagrant/api.go
@@ -55,13 +55,6 @@ func initMachine(cloudConfig string, size string, id string) error {
 	path := vdir + id
 	os.Mkdir(path, os.ModeDir|os.ModePerm)
 
-	_, stderr, err := shell(id, `vagrant --machine-readable init coreos-beta`)
-	if err != nil {
-		log.Errorf("Failed to initialize Vagrant environment: %s", stderr)
-		destroy(id)
-		return errors.New("unable to init machine")
-	}
-
 	err = util.WriteFile(path+"/user-data", []byte(cloudConfig), 0644)
 	if err != nil {
 		destroy(id)

--- a/cluster/vagrant/api.go
+++ b/cluster/vagrant/api.go
@@ -23,7 +23,9 @@ Vagrant.require_version ">= 1.6.0"
 
 size = File.open(SIZE_PATH).read.strip.split(",")
 Vagrant.configure(2) do |config|
-  config.vm.box = "boxcutter/ubuntu1604"
+  config.vm.box = "ubuntu/xenial64"
+
+	config.vm.box_version = "20170515.0.0"
 
   config.vm.network "private_network", type: "dhcp"
 
@@ -39,6 +41,8 @@ Vagrant.configure(2) do |config|
   end
 end
 `
+
+const boxVersion = "20170515.0.0"
 
 func initMachine(cloudConfig string, size string, id string) error {
 	vdir, err := vagrantDir()
@@ -154,7 +158,7 @@ func addBox(name string, provider string) error {
 		return nil
 	}
 	err = exec.Command(vagrantCmd, []string{"--machine-readable", "box", "add",
-		"--provider", provider, name}...).Run()
+		"--provider", provider, name, "--box-version", boxVersion}...).Run()
 	if err != nil {
 		return errors.New("unable to add box")
 	}

--- a/cluster/vagrant/api.go
+++ b/cluster/vagrant/api.go
@@ -61,7 +61,7 @@ func initMachine(cloudConfig string, size string, id string) error {
 		return err
 	}
 
-	err = util.WriteFile(path+"/vagrantFile", []byte(vagrantFile), 0644)
+	err = util.WriteFile(path+"/Vagrantfile", []byte(vagrantFile), 0644)
 	if err != nil {
 		destroy(id)
 		return err

--- a/cluster/vagrant/api_test.go
+++ b/cluster/vagrant/api_test.go
@@ -1,0 +1,54 @@
+package vagrant
+
+import (
+	"testing"
+
+	"github.com/quilt/quilt/util"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVagrantFile(t *testing.T) {
+	vagrantTemplate = "({{.CloudConfigPath}}) ({{.Box}}) ({{.BoxVersion}}) " +
+		"({{.SizePath}})"
+
+	box = "testBox"
+	boxVersion = "testVersion"
+
+	res := createVagrantFile()
+	exp := "(/user-data) (testBox) (testVersion) (/size)"
+	if res != exp {
+		t.Errorf("res: %s\nexp: %s", res, exp)
+	}
+}
+
+func TestInitMachine(t *testing.T) {
+	util.AppFs = afero.NewMemMapFs()
+
+	vagrantTemplate = "({{.CloudConfigPath}}) ({{.Box}}) ({{.BoxVersion}}) " +
+		"({{.SizePath}})"
+	cloudConfig := "testCloudConfig"
+	size := "2,2"
+	id := "testing"
+
+	initMachine(cloudConfig, size, id)
+
+	vdir, err := vagrantDir()
+
+	assert.Nil(t, err)
+
+	path := vdir + id
+
+	resCloudConfig, err := util.ReadFile(path + cloudConfigPath)
+	assert.Nil(t, err)
+	assert.Equal(t, cloudConfig, resCloudConfig)
+
+	resSize, err := util.ReadFile(path + sizePath)
+	assert.Nil(t, err)
+	assert.Equal(t, size, resSize)
+
+	resVagrantFile, err := util.ReadFile(path + vagrantFilePath)
+	assert.Nil(t, err)
+	expFile := createVagrantFile()
+	assert.Equal(t, expFile, resVagrantFile)
+}

--- a/cluster/vagrant/template.go
+++ b/cluster/vagrant/template.go
@@ -1,0 +1,27 @@
+package vagrant
+
+var vagrantTemplate = `
+CLOUD_CONFIG_PATH = File.join(File.dirname(__FILE__), "{{.CloudConfigPath}}")
+SIZE_PATH = File.join(File.dirname(__FILE__), "{{.SizePath}}")
+Vagrant.require_version ">= 1.6.0"
+
+size = File.open(SIZE_PATH).read.strip.split(",")
+Vagrant.configure(2) do |config|
+  config.vm.box = "{{.Box}}"
+
+	config.vm.box_version = "{{.BoxVersion}}"
+
+  config.vm.network "private_network", type: "dhcp"
+
+  ram=(size[0].to_f*1024).to_i
+  cpus=size[1]
+  config.vm.provider "virtualbox" do |v|
+    v.memory = ram
+    v.cpus = cpus
+  end
+
+  if File.exist?(CLOUD_CONFIG_PATH)
+    config.vm.provision "shell", path: "#{CLOUD_CONFIG_PATH}"
+  end
+end
+`

--- a/cluster/vagrant/vagrant.go
+++ b/cluster/vagrant/vagrant.go
@@ -20,7 +20,7 @@ type Cluster struct {
 // New creates a new vagrant cluster.
 func New(namespace string) (*Cluster, error) {
 	clst := Cluster{namespace}
-	err := addBox("ubuntu/xenial64", "virtualbox")
+	err := addBox(box, "virtualbox")
 	return &clst, err
 }
 

--- a/cluster/vagrant/vagrant.go
+++ b/cluster/vagrant/vagrant.go
@@ -20,7 +20,7 @@ type Cluster struct {
 // New creates a new vagrant cluster.
 func New(namespace string) (*Cluster, error) {
 	clst := Cluster{namespace}
-	err := addBox("boxcutter/ubuntu1604", "virtualbox")
+	err := addBox("ubuntu/xenial64", "virtualbox")
 	return &clst, err
 }
 


### PR DESCRIPTION
So one major thing is the network patch that @kklin made that doesn't restrict NAT rules by interface that is part of this PR. I'm not too sure what the specific consequences of that may be. I'll try to run `quilt-tester` on this with aws, but booting random specs seems to work on vagrant. I will write up/update the docs on that, possibly in a second PR.

But this patch should contain the general fixes to make Vagrant work and some small immediate improvements.