### PR TITLE
docs: Fix contact link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,4 +40,4 @@ release provides an alpha quality implementation which can deploy a whole [host
 of distributed applications](http://github.com/quilt) to Amazon EC2, Google
 Cloud Engine, or DigitalOcean.  We're excited to begin this journey with our
 inaugural release!  Please try it out and [let us
-know](http://quilt.io/contact.php) what you think.
+know](http://quilt.io/#contact) what you think.

--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ instructions on how to get your Quilt deployment up and running.
 ## Contact Us
 
 Questions? Comments? Feedback?  Please feel free to reach out to us
-[here](http://quilt.io/contact.php)!
+[here](http://quilt.io/#contact)!


### PR DESCRIPTION
When the website was recently update, the contact information moved to
the main page.  This patch fixes the relevant links.