### PR TITLE
command: Embed connectionHelper directly

### DIFF
--- a/quiltctl/command/debug.go
+++ b/quiltctl/command/debug.go
@@ -41,7 +41,7 @@ type Debug struct {
 
 	sshGetter ssh.Getter
 
-	*connectionHelper
+	connectionHelper
 }
 
 type logTarget struct {
@@ -99,10 +99,7 @@ var (
 
 // NewDebugCommand creates a new Debug command instance.
 func NewDebugCommand() *Debug {
-	return &Debug{
-		sshGetter:        ssh.New,
-		connectionHelper: &connectionHelper{},
-	}
+	return &Debug{sshGetter: ssh.New}
 }
 
 var debugUsage = `usage: quilt debug-logs [-v] [-tar=<true/false>] [-i <keyfile>]` +

--- a/quiltctl/command/debug_test.go
+++ b/quiltctl/command/debug_test.go
@@ -448,7 +448,7 @@ func TestDebug(t *testing.T) {
 			MachineReturn:   test.machines,
 			ContainerReturn: test.containers,
 		}
-		testCmd.connectionHelper = &connectionHelper{
+		testCmd.connectionHelper = connectionHelper{
 			client: mockLocalClient,
 		}
 

--- a/quiltctl/command/log.go
+++ b/quiltctl/command/log.go
@@ -22,15 +22,12 @@ type Log struct {
 
 	sshGetter ssh.Getter
 
-	*connectionHelper
+	connectionHelper
 }
 
 // NewLogCommand creates a new Log command instance.
 func NewLogCommand() *Log {
-	return &Log{
-		sshGetter:        ssh.New,
-		connectionHelper: &connectionHelper{},
-	}
+	return &Log{sshGetter: ssh.New}
 }
 
 var logsUsage = `usage: quilt logs [-H=<daemon_host>] [-i=<private_key>] <stitch_id>

--- a/quiltctl/command/log_test.go
+++ b/quiltctl/command/log_test.go
@@ -127,7 +127,7 @@ func TestLog(t *testing.T) {
 			return mockSSHClient, nil
 		}
 		testCmd.privateKey = "key"
-		testCmd.connectionHelper = &connectionHelper{client: mockLocalClient}
+		testCmd.connectionHelper = connectionHelper{client: mockLocalClient}
 
 		mockSSHClient.On("Run", false, test.expSSHCommand).Return(nil)
 		mockSSHClient.On("Close").Return(nil)
@@ -144,7 +144,7 @@ func TestLogAmbiguousID(t *testing.T) {
 		ContainerReturn: []db.Container{{StitchID: "foo"}},
 	}
 	testCmd := Log{
-		connectionHelper: &connectionHelper{client: mockClient},
+		connectionHelper: connectionHelper{client: mockClient},
 		target:           "foo",
 	}
 	assert.Equal(t, 1, testCmd.Run())
@@ -157,7 +157,7 @@ func TestLogNoMatch(t *testing.T) {
 	}
 
 	testCmd := Log{
-		connectionHelper: &connectionHelper{client: mockClient},
+		connectionHelper: connectionHelper{client: mockClient},
 		target:           "bar",
 	}
 	assert.Equal(t, 1, testCmd.Run())
@@ -169,7 +169,7 @@ func TestLogScheduledContainer(t *testing.T) {
 	}
 
 	testCmd := Log{
-		connectionHelper: &connectionHelper{client: mockClient},
+		connectionHelper: connectionHelper{client: mockClient},
 		target:           "foo",
 	}
 	assert.Equal(t, 1, testCmd.Run())

--- a/quiltctl/command/ps.go
+++ b/quiltctl/command/ps.go
@@ -23,14 +23,12 @@ const truncLength = 30
 type Ps struct {
 	noTruncate bool
 
-	*connectionHelper
+	connectionHelper
 }
 
 // NewPsCommand creates a new Ps command instance.
 func NewPsCommand() *Ps {
-	return &Ps{
-		connectionHelper: &connectionHelper{},
-	}
+	return &Ps{}
 }
 
 // InstallFlags sets up parsing for command line flags

--- a/quiltctl/command/ps_test.go
+++ b/quiltctl/command/ps_test.go
@@ -40,12 +40,12 @@ func TestPsErrors(t *testing.T) {
 
 	// Error querying containers
 	mockClient := &mocks.Client{ContainerErr: mockErr}
-	cmd := &Ps{false, &connectionHelper{client: mockClient}}
+	cmd := &Ps{false, connectionHelper{client: mockClient}}
 	assert.EqualError(t, cmd.run(), "unable to query containers: error")
 
 	// Error querying connections from LeaderClient
 	mockClient = &mocks.Client{ConnectionErr: mockErr}
-	cmd = &Ps{false, &connectionHelper{client: mockClient}}
+	cmd = &Ps{false, connectionHelper{client: mockClient}}
 	assert.EqualError(t, cmd.run(), "unable to query connections: error")
 }
 
@@ -53,7 +53,7 @@ func TestPsSuccess(t *testing.T) {
 	t.Parallel()
 
 	mockClient := new(mocks.Client)
-	cmd := &Ps{false, &connectionHelper{client: mockClient}}
+	cmd := &Ps{false, connectionHelper{client: mockClient}}
 	assert.Equal(t, 0, cmd.Run())
 }
 

--- a/quiltctl/command/run.go
+++ b/quiltctl/command/run.go
@@ -24,14 +24,12 @@ type Run struct {
 	stitch string
 	force  bool
 
-	*connectionHelper
+	connectionHelper
 }
 
 // NewRunCommand creates a new Run command instance.
 func NewRunCommand() *Run {
-	return &Run{
-		connectionHelper: &connectionHelper{},
-	}
+	return &Run{}
 }
 
 // InstallFlags sets up parsing for command line flags.

--- a/quiltctl/command/run_test.go
+++ b/quiltctl/command/run_test.go
@@ -206,7 +206,7 @@ func TestPromptsUser(t *testing.T) {
 
 		util.WriteFile("test.js", []byte(""), 0644)
 		runCmd := &Run{
-			connectionHelper: &connectionHelper{client: c},
+			connectionHelper: connectionHelper{client: c},
 			stitch:           "test.js",
 		}
 		runCmd.Run()

--- a/quiltctl/command/ssh.go
+++ b/quiltctl/command/ssh.go
@@ -25,15 +25,12 @@ type SSH struct {
 
 	sshGetter ssh.Getter
 
-	*connectionHelper
+	connectionHelper
 }
 
 // NewSSHCommand creates a new SSH command instance.
 func NewSSHCommand() *SSH {
-	return &SSH{
-		sshGetter:        ssh.New,
-		connectionHelper: &connectionHelper{},
-	}
+	return &SSH{sshGetter: ssh.New}
 }
 
 var sshUsage = `usage: quilt ssh <id> [command]

--- a/quiltctl/command/ssh_test.go
+++ b/quiltctl/command/ssh_test.go
@@ -71,10 +71,10 @@ func TestSSHFlags(t *testing.T) {
 func TestSSHPTY(t *testing.T) {
 	isTerminal = func() bool { return false }
 	assert.Equal(t, 1, SSH{
-		connectionHelper: &connectionHelper{client: &mocks.Client{}},
+		connectionHelper: connectionHelper{client: &mocks.Client{}},
 	}.Run())
 	assert.Equal(t, 1, SSH{
-		connectionHelper: &connectionHelper{client: &mocks.Client{}},
+		connectionHelper: connectionHelper{client: &mocks.Client{}},
 		args:             []string{"foo"},
 		allocatePTY:      true,
 	}.Run())
@@ -254,7 +254,7 @@ func TestSSH(t *testing.T) {
 			MachineReturn:   test.machines,
 			ContainerReturn: test.containers,
 		}
-		testCmd.connectionHelper = &connectionHelper{client: mockClient}
+		testCmd.connectionHelper = connectionHelper{client: mockClient}
 
 		assert.Equal(t, 0, testCmd.Run())
 		mockSSHClient.AssertExpectations(t)
@@ -267,7 +267,7 @@ func TestAmbiguousID(t *testing.T) {
 		ContainerReturn: []db.Container{{StitchID: "foo"}},
 	}
 	testCmd := SSH{
-		connectionHelper: &connectionHelper{client: mockClient},
+		connectionHelper: connectionHelper{client: mockClient},
 		target:           "foo",
 	}
 	assert.Equal(t, 1, testCmd.Run())
@@ -279,7 +279,7 @@ func TestNoMatch(t *testing.T) {
 		ContainerReturn: []db.Container{{StitchID: "foo"}},
 	}
 	testCmd := SSH{
-		connectionHelper: &connectionHelper{client: mockClient},
+		connectionHelper: connectionHelper{client: mockClient},
 		target:           "bar",
 	}
 	assert.Equal(t, 1, testCmd.Run())
@@ -298,7 +298,7 @@ func TestSSHExitError(t *testing.T) {
 		MachineReturn: []db.Machine{{StitchID: "tgt"}},
 	}
 	testCmd := SSH{
-		connectionHelper: &connectionHelper{client: mockLocalClient},
+		connectionHelper: connectionHelper{client: mockLocalClient},
 		sshGetter:        mockSSHGetter,
 		target:           "tgt",
 		args:             []string{"unused"},
@@ -314,7 +314,7 @@ func TestSSHExitError(t *testing.T) {
 	mockSSHClient.On("Run", mock.Anything, mock.Anything).Return(errors.New("error"))
 
 	testCmd = SSH{
-		connectionHelper: &connectionHelper{client: mockLocalClient},
+		connectionHelper: connectionHelper{client: mockLocalClient},
 		sshGetter:        mockSSHGetter,
 		target:           "tgt",
 		args:             []string{"unused"},
@@ -337,7 +337,7 @@ func TestSSHScheduledContainer(t *testing.T) {
 		ContainerReturn: []db.Container{{StitchID: "foo"}},
 	}
 	testCmd := SSH{
-		connectionHelper: &connectionHelper{client: mockClient},
+		connectionHelper: connectionHelper{client: mockClient},
 		target:           "foo",
 	}
 	assert.Equal(t, 1, testCmd.Run())

--- a/quiltctl/command/stop.go
+++ b/quiltctl/command/stop.go
@@ -14,14 +14,12 @@ type Stop struct {
 	namespace      string
 	onlyContainers bool
 
-	*connectionHelper
+	connectionHelper
 }
 
 // NewStopCommand creates a new Stop command instance.
 func NewStopCommand() *Stop {
-	return &Stop{
-		connectionHelper: &connectionHelper{},
-	}
+	return &Stop{}
 }
 
 // InstallFlags sets up parsing for command line flags.

--- a/quiltctl/command/version.go
+++ b/quiltctl/command/version.go
@@ -11,14 +11,12 @@ import (
 
 // Version prints the Quilt version information.
 type Version struct {
-	*connectionHelper
+	connectionHelper
 }
 
 // NewVersionCommand creates a new Version command instance.
 func NewVersionCommand() *Version {
-	return &Version{
-		connectionHelper: &connectionHelper{},
-	}
+	return &Version{}
 }
 
 var versionUsage = `usage: quilt version [-H=<daemon_host>]

--- a/quiltctl/command/version_test.go
+++ b/quiltctl/command/version_test.go
@@ -27,7 +27,7 @@ func TestGetDaemonVersion(t *testing.T) {
 		VersionReturn: "mockVersion",
 	}
 	vCmd := Version{
-		connectionHelper: &connectionHelper{client: mockLocalClient},
+		connectionHelper: connectionHelper{client: mockLocalClient},
 	}
 
 	res := vCmd.Run()


### PR DESCRIPTION
This patch causes connectionHelper to be embedded directly into the
various structs that need it, instead of embedding a pointer.  This
slightly simplifies the code.