### PR TITLE
tests: Add integration test for HAProxy

### DIFF
--- a/quilt-tester/tests/30-mean/mean.js
+++ b/quilt-tester/tests/30-mean/mean.js
@@ -21,7 +21,6 @@ let app = new Node({
 // general style.
 let proxy = haproxy.singleServiceLoadBalancer(3, app._app);
 
-mongo.connect(mongo.port, app);
 app.connect(mongo.port, mongo);
 proxy.allowFrom(publicInternet, haproxy.exposedPort);
 

--- a/quilt-tester/tests/haproxy/haproxy.js
+++ b/quilt-tester/tests/haproxy/haproxy.js
@@ -1,0 +1,41 @@
+const quilt = require('@quilt/quilt');
+const hap = require('@quilt/haproxy');
+let infrastructure = require('../../config/infrastructure.js');
+
+const indexPath = '/usr/share/nginx/html/index.html';
+
+/**
+ * Returns a new Container whose index file contains the given content.
+ * @param {string} content - The contents to put in the container's index file.
+ * @return {Container} - A container with given content in its index file.
+ */
+function containerWithContent(content) {
+  let files = {};
+  files[indexPath] = content;
+  return new quilt.Container('nginx').withFiles(files);
+};
+
+let serviceA = new quilt.Service('serviceA', [
+  containerWithContent('a1'),
+  containerWithContent('a2'),
+]);
+
+let serviceB = new quilt.Service('serviceB', [
+  containerWithContent('b1'),
+  containerWithContent('b2'),
+  containerWithContent('b3'),
+]);
+
+let proxy = hap.withURLrouting(2, {
+  'serviceB.com': serviceB,
+  'serviceA.com': serviceA,
+});
+
+proxy.allowFrom(quilt.publicInternet, 80);
+
+let inf = quilt.createDeployment();
+
+inf.deploy(infrastructure);
+inf.deploy(serviceA);
+inf.deploy(serviceB);
+inf.deploy(proxy);

--- a/quilt-tester/tests/haproxy/haproxy_test.go
+++ b/quilt-tester/tests/haproxy/haproxy_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/quilt/quilt/api"
+	"github.com/quilt/quilt/api/client"
+	"github.com/quilt/quilt/connection/credentials"
+	"github.com/quilt/quilt/db"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const cookieName string = "SERVERID"
+
+func TestURLrouting(t *testing.T) {
+	clnt, err := client.New(api.DefaultSocket, credentials.Insecure{})
+	if err != nil {
+		t.Fatalf("couldn't get quiltctl client: %s", err)
+	}
+	defer clnt.Close()
+
+	containers, err := clnt.QueryContainers()
+	if err != nil {
+		t.Fatalf("couldn't query containers: %s", err)
+	}
+
+	machines, err := clnt.QueryMachines()
+	if err != nil {
+		t.Fatalf("couldn't query machines: %s", err)
+	}
+
+	HAProxyIPs := getHAproxyIPs(t, machines, containers)
+	if len(HAProxyIPs) == 0 {
+		t.Fatal("Found no public IPs for HAProxy")
+	}
+	log.Info("Public proxy IPs: ", HAProxyIPs)
+
+	expectedA := map[string]struct{}{
+		"a1": {},
+		"a2": {},
+	}
+
+	expectedB := map[string]struct{}{
+		"b1": {},
+		"b2": {},
+		"b3": {},
+	}
+
+	httpGetTest(t, "serviceA.com", HAProxyIPs, expectedA)
+	httpGetTest(t, "serviceB.com", HAProxyIPs, expectedB)
+	cookieTest(t, "serviceA.com", HAProxyIPs, expectedA)
+	cookieTest(t, "serviceB.com", HAProxyIPs, expectedB)
+	badDomainTest(t, "badDomain.com", HAProxyIPs)
+}
+
+func httpGetTest(t *testing.T, domain string, HAProxyIPs []string,
+	expected map[string]struct{}) {
+
+	log.Info("Http GET test for ", domain)
+	client := &http.Client{}
+	checkResponses(t, domain, HAProxyIPs, expected, "", client)
+}
+
+func cookieTest(t *testing.T, domain string, HAProxyIPs []string,
+	expected map[string]struct{}) {
+
+	log.Info("Cookie test for ", domain)
+	client := &http.Client{}
+
+	// We just need a cookie from some proxy.
+	resp, err := makeRequest(domain, HAProxyIPs[0], client, "")
+	if err != nil {
+		t.Errorf("failed to request %s: %s", domain, err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("bad status code: %d", resp.StatusCode)
+	}
+
+	var cookie string
+	for _, c := range resp.Cookies() {
+		if c.Name == cookieName {
+			cookie = c.Value
+		}
+	}
+
+	if cookie == "" {
+		t.Errorf("no cookie received for %s: %s", domain, err)
+	}
+
+	body, err := getBody(resp)
+	if err != nil {
+		t.Errorf("couldn't read response body: %s", err)
+	}
+
+	if _, ok := expected[body]; !ok {
+		t.Errorf("received bad body: %s", body)
+	}
+
+	// With the Session Cookie set, we expect to always talk to the same server.
+	newExpected := map[string]struct{}{
+		body: {},
+	}
+
+	checkResponses(t, domain, HAProxyIPs, newExpected, cookie, client)
+}
+
+func badDomainTest(t *testing.T, domain string, HAProxyIPs []string) {
+	log.Info("Bad domain test for ", domain)
+	client := &http.Client{}
+
+	for _, ip := range HAProxyIPs {
+		resp, err := makeRequest(domain, ip, client, "")
+		if err != nil {
+			t.Errorf("request failed to %s: %s", ip, err)
+		}
+
+		if resp.StatusCode != 503 {
+			t.Errorf("got unexpected response for bad domain from %s: %v",
+				ip, resp)
+		}
+	}
+}
+
+func checkResponses(t *testing.T, domain string, HAProxyIPs []string,
+	expected map[string]struct{}, cookie string, client *http.Client) {
+
+	for i := 0; i < 15; i++ {
+		for _, ip := range HAProxyIPs {
+			resp, err := makeRequest(domain, ip, client, cookie)
+			if err != nil {
+				t.Errorf("request failed: %s", err)
+				continue
+			}
+
+			if resp.StatusCode != 200 {
+				t.Errorf("bad status code: %d", resp.StatusCode)
+				continue
+			}
+
+			body, err := getBody(resp)
+			if err != nil {
+				t.Errorf("couldn't read response body: %s", err)
+				continue
+			}
+
+			if _, ok := expected[body]; !ok {
+				t.Errorf("wrong HTTP response: %s", body)
+			}
+		}
+	}
+}
+
+func getHAproxyIPs(t *testing.T, machines []db.Machine,
+	containers []db.Container) []string {
+
+	minionIPMap := map[string]string{}
+	for _, m := range machines {
+		minionIPMap[m.PrivateIP] = m.PublicIP
+	}
+
+	var ips []string
+	for _, c := range containers {
+		if strings.Contains(c.Image, "haproxy") {
+			ip, ok := minionIPMap[c.Minion]
+			if !ok {
+				t.Errorf("HAProxy with no public IP: %s", c)
+				continue
+			}
+			ips = append(ips, ip)
+		}
+	}
+	return ips
+}
+
+func makeRequest(domain string, HAProxyIP string, client *http.Client,
+	cookie string) (*http.Response, error) {
+
+	ip := "http://" + HAProxyIP
+	req, err := http.NewRequest("GET", ip, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{
+			Name:  cookieName,
+			Value: cookie,
+		})
+	}
+
+	req.Host = domain
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func getBody(resp *http.Response) (string, error) {
+	defer resp.Body.Close()
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}


### PR DESCRIPTION
This commit adds an integration test for the updated HAProxy blueprint. It should not be merged until the [updated HAProxy blueprint](https://github.com/quilt/haproxy/pull/6) has been merged.