### PR TITLE
codecov: Tweak ignore directive

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -22,4 +22,5 @@ parsers:
   javascript:
     enable_partials: false
 ignore:
-    - "**/mock*"
+    - "**/*mock*"
+    - "/quilt-tester"


### PR DESCRIPTION
We were covering both etcd_mock.go and quilt-tester, neither of which
users interact with, and thus should be excluded.