### PR TITLE
openflow: Enforce ACLs for traffic to and from public

### DIFF
--- a/minion/network/openflow/openflow_test.go
+++ b/minion/network/openflow/openflow_test.go
@@ -72,20 +72,46 @@ func TestAllFlows(t *testing.T) {
 	flows := allFlows([]container{{
 		patchPort: 4,
 		vethPort:  5,
-		Container: Container{Mac: "66:66:66:66:66:66"},
+		Container: Container{
+			IP:    "6.7.8.9",
+			Mac:   "66:66:66:66:66:66",
+			ToPub: map[int]struct{}{5: {}}},
 	}, {
 		patchPort: 9,
 		vethPort:  8,
-		Container: Container{Mac: "99:99:99:99:99:99"}}})
+		Container: Container{
+			IP:      "9.8.7.6",
+			Mac:     "99:99:99:99:99:99",
+			FromPub: map[int]struct{}{8: {}}}}})
 	exp := append(staticFlows,
 		"table=0,in_port=5,dl_src=66:66:66:66:66:66,"+
 			"actions=load:0x4->NXM_NX_REG0[],resubmit(,1)",
 		"table=0,in_port=4,actions=output:5",
-		"table=2,priority=900,dl_dst=66:66:66:66:66:66,action=output:5",
+		"table=2,priority=900,arp,dl_dst=66:66:66:66:66:66,action=output:5",
+		"table=2,priority=800,ip,dl_dst=66:66:66:66:66:66,nw_src=10.0.0.1,"+
+			"action=output:5",
+		"table=2,priority=500,tcp,dl_dst=66:66:66:66:66:66,ip_dst=6.7.8.9,"+
+			"tp_src=5,actions=output:5",
+		"table=2,priority=500,udp,dl_dst=66:66:66:66:66:66,ip_dst=6.7.8.9,"+
+			"tp_src=5,actions=output:5",
+		"table=3,priority=500,tcp,dl_src=66:66:66:66:66:66,ip_src=6.7.8.9,"+
+			"tp_dst=5,actions=output:LOCAL",
+		"table=3,priority=500,udp,dl_src=66:66:66:66:66:66,ip_src=6.7.8.9,"+
+			"tp_dst=5,actions=output:LOCAL",
 		"table=0,in_port=8,dl_src=99:99:99:99:99:99,"+
 			"actions=load:0x9->NXM_NX_REG0[],resubmit(,1)",
 		"table=0,in_port=9,actions=output:8",
-		"table=2,priority=900,dl_dst=99:99:99:99:99:99,action=output:8",
+		"table=2,priority=900,arp,dl_dst=99:99:99:99:99:99,action=output:8",
+		"table=2,priority=800,ip,dl_dst=99:99:99:99:99:99,nw_src=10.0.0.1,"+
+			"action=output:8",
+		"table=2,priority=500,tcp,dl_dst=99:99:99:99:99:99,ip_dst=9.8.7.6,"+
+			"tp_dst=8,actions=output:8",
+		"table=2,priority=500,udp,dl_dst=99:99:99:99:99:99,ip_dst=9.8.7.6,"+
+			"tp_dst=8,actions=output:8",
+		"table=3,priority=500,tcp,dl_src=99:99:99:99:99:99,ip_src=9.8.7.6,"+
+			"tp_src=8,actions=output:LOCAL",
+		"table=3,priority=500,udp,dl_src=99:99:99:99:99:99,ip_src=9.8.7.6,"+
+			"tp_src=8,actions=output:LOCAL",
 		"table=2,priority=1000,dl_dst=ff:ff:ff:ff:ff:ff,"+
 			"actions=output:5,output:8")
 	assert.Equal(t, exp, flows)

--- a/minion/network/openflow/openflow_test.go
+++ b/minion/network/openflow/openflow_test.go
@@ -69,9 +69,14 @@ func TestAddReplaceFlows(t *testing.T) {
 
 func TestAllFlows(t *testing.T) {
 	t.Parallel()
-	flows := allFlows([]container{
-		{patch: 4, veth: 5, mac: "66:66:66:66:66:66"},
-		{patch: 9, veth: 8, mac: "99:99:99:99:99:99"}})
+	flows := allFlows([]container{{
+		patchPort: 4,
+		vethPort:  5,
+		Container: Container{Mac: "66:66:66:66:66:66"},
+	}, {
+		patchPort: 9,
+		vethPort:  8,
+		Container: Container{Mac: "99:99:99:99:99:99"}}})
 	exp := append(staticFlows,
 		"table=0,in_port=5,dl_src=66:66:66:66:66:66,"+
 			"actions=load:0x4->NXM_NX_REG0[],resubmit(,1)",
@@ -92,5 +97,8 @@ func TestResolveContainers(t *testing.T) {
 	res := resolveContainers(map[string]int{"a": 3, "b": 4}, []Container{
 		{Veth: "a", Patch: "b", Mac: "mac"},
 		{Veth: "c", Patch: "d", Mac: "mac2"}})
-	assert.Equal(t, []container{{veth: 3, patch: 4, mac: "mac"}}, res)
+	assert.Equal(t, []container{{
+		vethPort:  3,
+		patchPort: 4,
+		Container: Container{Veth: "a", Patch: "b", Mac: "mac"}}}, res)
 }

--- a/minion/network/openflow/openflow_test.go
+++ b/minion/network/openflow/openflow_test.go
@@ -54,7 +54,7 @@ func TestAddReplaceFlows(t *testing.T) {
 	client.AssertCalled(t, "OpenFlowPorts")
 
 	assert.Equal(t, map[string][]string{
-		"add-flows": containerFlows(nil),
+		"add-flows": nil,
 	}, actionsToFlows)
 
 	ofctl = func(a string, f []string) error { return anErr }

--- a/minion/network/plugin/plugin.go
+++ b/minion/network/plugin/plugin.go
@@ -112,7 +112,11 @@ func (d driver) CreateEndpoint(req *dnet.CreateEndpointRequest) (
 		return nil, fmt.Errorf("ovs-vsctl: %v", err)
 	}
 
-	err = ofctl(openflow.Container{Veth: outer, Patch: peerQuilt, Mac: mac})
+	err = ofctl(openflow.Container{
+		Veth:  outer,
+		Patch: peerQuilt,
+		Mac:   mac,
+		IP:    addr.String()})
 	if err != nil {
 		// Problems with OpenFlow can be repaired later so just log.
 		log.WithError(err).Warn("Failed to add OpenFlow rules")


### PR DESCRIPTION
Before this patch, if a container attempted to send packets to the
public internet without permission to.  That packet would leave the
container, traverse our OVS bridge, traverse the NAT unchanged, and be
dumped out onto the public internet with the containers internal
private source IP address.  This is obviously very bad.

This patch solves the issue by enforcing public internet ACLs in the
OpenFlow tables.  Thus, if a container attempts to send a packet to
public that's not allowed, it will be dropped before it leaves the
Quilt OVS bridge.