### PR TITLE
ctl: Rename `ps` to `show` while keeping `ps` as an alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ fixes a bug where containers would sometimes fail to resolve DNS on DigitalOcean
 that had already been booted. This most visibly resulted in containers restarting.
 - Use an exponential backoff algorithm when waiting for cloud provider actions
 to complete. This decreases the number of cloud provider API calls done by Quilt.
-- `quilt ps` now displays the image building status of custom Dockerfiles.
+- `quilt ps` is now renamed to `quilt show`, though the original `quilt ps`
+  still works as an alias to `quilt show`.
+- `quilt show` now displays the image building status of custom Dockerfiles.
 - Let blueprints write to stdout. Before, if blueprints used `console.log`, the
 text printed to stdout would break the deployment object.
-- `quilt ps` now has more status options for machines (booting, connecting,
+- `quilt show` now has more status options for machines (booting, connecting,
 connected, and reconnecting).
 - Allow an admin SSH key access to all machines deployed by the daemon. The key is
 specified using the `admin-ssh-private-key` flag to the daemon.

--- a/quilt.go
+++ b/quilt.go
@@ -25,7 +25,7 @@ To see the help text for a given command:
 quilt COMMAND --help
 
 Commands:
-  counters, daemon, debug-logs, inspect, logs, minion, ps, run, ssh, stop,
+  counters, daemon, debug-logs, inspect, logs, minion, show, run, ssh, stop,
   version, setup-tls`
 
 func main() {

--- a/quiltctl/command/show.go
+++ b/quiltctl/command/show.go
@@ -19,38 +19,38 @@ import (
 // An arbitrary length to truncate container commands to.
 const truncLength = 30
 
-// Ps contains the options for querying machines and containers.
-type Ps struct {
+// Show contains the options for querying machines and containers.
+type Show struct {
 	noTruncate bool
 
 	connectionHelper
 }
 
-// NewPsCommand creates a new Ps command instance.
-func NewPsCommand() *Ps {
-	return &Ps{}
+// NewShowCommand creates a new Show command instance.
+func NewShowCommand() *Show {
+	return &Show{}
 }
 
-var psCommands = "quilt ps [OPTIONS]"
-var psExplanation = "Display the status of quilt-managed machines and containers."
+var showCommands = "quilt show [OPTIONS]"
+var showExplanation = "Display the status of quilt-managed machines and containers."
 
 // InstallFlags sets up parsing for command line flags
-func (pCmd *Ps) InstallFlags(flags *flag.FlagSet) {
+func (pCmd *Show) InstallFlags(flags *flag.FlagSet) {
 	pCmd.connectionHelper.InstallFlags(flags)
 	flags.BoolVar(&pCmd.noTruncate, "no-trunc", false, "do not truncate container"+
 		" command output")
 	flags.Usage = func() {
-		util.PrintUsageString(psCommands, psExplanation, flags)
+		util.PrintUsageString(showCommands, showExplanation, flags)
 	}
 }
 
-// Parse parses the command line arguments for the ps command.
-func (pCmd *Ps) Parse(args []string) error {
+// Parse parses the command line arguments for the show command.
+func (pCmd *Show) Parse(args []string) error {
 	return nil
 }
 
 // Run retrieves and prints all machines and containers.
-func (pCmd *Ps) Run() int {
+func (pCmd *Show) Run() int {
 	if err := pCmd.run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		return 1
@@ -58,7 +58,7 @@ func (pCmd *Ps) Run() int {
 	return 0
 }
 
-func (pCmd *Ps) run() (err error) {
+func (pCmd *Show) run() (err error) {
 	machines, err := pCmd.client.QueryMachines()
 	if err != nil {
 		return fmt.Errorf("unable to query machines: %s", err)

--- a/quiltctl/command/show_test.go
+++ b/quiltctl/command/show_test.go
@@ -15,25 +15,25 @@ import (
 	"github.com/quilt/quilt/db"
 )
 
-func TestPsFlags(t *testing.T) {
+func TestShowFlags(t *testing.T) {
 	t.Parallel()
 
 	expHost := "IP"
 
-	cmd := NewPsCommand()
+	cmd := NewShowCommand()
 	err := parseHelper(cmd, []string{"-H", expHost})
 
 	assert.NoError(t, err)
 	assert.Equal(t, expHost, cmd.host)
 
-	cmd = NewPsCommand()
+	cmd = NewShowCommand()
 	err = parseHelper(cmd, []string{"-no-trunc"})
 
 	assert.NoError(t, err)
 	assert.True(t, cmd.noTruncate)
 }
 
-func TestPsErrors(t *testing.T) {
+func TestShowErrors(t *testing.T) {
 	t.Parallel()
 
 	mockErr := errors.New("error")
@@ -44,7 +44,7 @@ func TestPsErrors(t *testing.T) {
 	mockClient.On("QueryMachines").Return([]db.Machine{{Status: db.Connected}}, nil)
 	mockClient.On("QueryContainers").Return(nil, mockErr)
 	mockClient.On("QueryImages").Return(nil, nil)
-	cmd := &Ps{false, connectionHelper{client: mockClient}}
+	cmd := &Show{false, connectionHelper{client: mockClient}}
 	assert.EqualError(t, cmd.run(), "unable to query containers: error")
 
 	// Error querying connections from LeaderClient
@@ -53,7 +53,7 @@ func TestPsErrors(t *testing.T) {
 	mockClient.On("QueryMachines").Return([]db.Machine{{Status: db.Connected}}, nil)
 	mockClient.On("QueryConnections").Return(nil, mockErr)
 	mockClient.On("QueryImages").Return(nil, nil)
-	cmd = &Ps{false, connectionHelper{client: mockClient}}
+	cmd = &Show{false, connectionHelper{client: mockClient}}
 	assert.EqualError(t, cmd.run(), "unable to query connections: error")
 }
 
@@ -62,7 +62,7 @@ func TestMachineOnly(t *testing.T) {
 	t.Parallel()
 
 	mockClient := new(mocks.Client)
-	cmd := &Ps{false, connectionHelper{client: mockClient}}
+	cmd := &Show{false, connectionHelper{client: mockClient}}
 
 	// Test failing to query machines.
 	mockClient.On("QueryMachines").Once().Return(nil, assert.AnError)
@@ -81,7 +81,7 @@ func TestMachineOnly(t *testing.T) {
 	mockClient.AssertNotCalled(t, "QueryContainers")
 }
 
-func TestPsSuccess(t *testing.T) {
+func TestShowSuccess(t *testing.T) {
 	t.Parallel()
 
 	mockClient := new(mocks.Client)
@@ -89,7 +89,7 @@ func TestPsSuccess(t *testing.T) {
 	mockClient.On("QueryMachines").Return(nil, nil)
 	mockClient.On("QueryConnections").Return(nil, nil)
 	mockClient.On("QueryImages").Return(nil, nil)
-	cmd := &Ps{false, connectionHelper{client: mockClient}}
+	cmd := &Show{false, connectionHelper{client: mockClient}}
 	assert.Equal(t, 0, cmd.Run())
 }
 

--- a/quiltctl/quiltctl.go
+++ b/quiltctl/quiltctl.go
@@ -11,10 +11,13 @@ import (
 
 // Note the `minion` command is in quiltclt_posix.go as it only runs on posix systems.
 var commands = map[string]command.SubCommand{
-	"daemon":     command.NewDaemonCommand(),
-	"inspect":    &command.Inspect{},
-	"logs":       command.NewLogCommand(),
-	"ps":         command.NewPsCommand(),
+	"daemon":  command.NewDaemonCommand(),
+	"inspect": &command.Inspect{},
+	"logs":    command.NewLogCommand(),
+
+	"ps":   command.NewShowCommand(),
+	"show": command.NewShowCommand(),
+
 	"run":        command.NewRunCommand(),
 	"setup-tls":  &command.SetupTLS{},
 	"ssh":        command.NewSSHCommand(),


### PR DESCRIPTION
Most people don't know what `ps` is, making the `quilt ps` command
seem jargony and inaccessible.  `show` is much more descriptive and
should be the default.  That said, `ps` is used in other tools, and
some users may expect it to work.  So this patch allows either to be
used.