### PR TITLE
scheduler: Avoid spurious warning on port ranges

### DIFF
--- a/minion/scheduler/worker.go
+++ b/minion/scheduler/worker.go
@@ -222,6 +222,11 @@ func openflowContainers(dbcs []db.Container,
 	fromPubPorts := map[string][]int{}
 	toPubPorts := map[string][]int{}
 	for _, conn := range conns {
+		if conn.From != stitch.PublicInternetLabel &&
+			conn.To != stitch.PublicInternetLabel {
+			continue
+		}
+
 		if conn.MinPort != conn.MaxPort {
 			c.Inc("Unsupported Public Port Range")
 			log.WithField("connection", conn).Debug(


### PR DESCRIPTION
The minion currently does not support port ranges for public internet,
and logs a warning to aid in debugging.  Unfortunately, that warning
was incorrectly being logged for port ranges over *internal* traffic.
This patch suppresses the warning in that case.