### PR TITLE
docs: Makefile should copy content, not directories

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,10 +1,10 @@
 # Compiles all of the docs in docs/build.
 all: build/slate
 	cd build/slate && \
-	cp -r ${CURDIR}/source/ source/ && \
+	cp -r ${CURDIR}/source/* source/ && \
 	cp -r ${CURDIR}/*md source/ && \
 	bundle exec middleman build --clean && \
-	cp -r build/ ${CURDIR}/build/ && \
+	cp -r build/* ${CURDIR}/build/ && \
 	echo "docs successfully compiled to HTML. To view docs, run:" && \
 	echo "  open build/index.html"
 


### PR DESCRIPTION
Before, the Makefile would create `build` and `source` directories instead of
copying the contents of those directories into the /site/ directory for the
docs container.