### PR TITLE
make: Don't run `govendor` when creating coverage targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,16 +74,15 @@ COV_SKIP= /api/client/mocks \
 	  /scripts/format \
 	  /version
 
-COV_PKG = $(subst github.com/quilt/quilt,,$(PACKAGES))
-go-coverage: $(addsuffix .cov, $(filter-out $(COV_SKIP), $(COV_PKG)))
+go-coverage:
+	for package in $(filter-out $(COV_SKIP), $(subst github.com/quilt/quilt,,$(PACKAGES))) ; do \
+	    go test -coverprofile=.$$package.cov .$$package && \
+	    go tool cover -html=.$$package.cov -o .$$package.html ; \
+	done
 	echo "" > coverage.txt
 	for f in $^ ; do \
 	    cat .$$f >> coverage.txt ; \
 	done
-
-%.cov:
-	go test -coverprofile=.$@ .$*
-	go tool cover -html=.$@ -o .$@.html
 
 js-coverage:
 	npm run-script cov > bindings.lcov


### PR DESCRIPTION
Because the `go-coverage` target depends the PACKAGES variable, make
was calling govendor whether or not that target was eventually
evaluated.  The govendor tool may not be installed when a user first
runs `make go-get`, so this would cause spurious warnings.  This patch
pulls the calculation of targets into the body of `go-coverage`,
causing it only to be evaluated when needed.

Reported-By: Diman Todorov <diman.todorov@gmail.com>