### PR TITLE
ovs: Update to the latest digital ocean kernel version

### DIFF
--- a/ovs/Dockerfile
+++ b/ovs/Dockerfile
@@ -4,7 +4,7 @@ COPY run /bin/run
 COPY bootstrap /bin/bootstrap
 
 RUN /bin/bootstrap binaries
-RUN /bin/bootstrap kernel_modules 4.4.0-62-generic 4.4.0-83-generic
+RUN /bin/bootstrap kernel_modules 4.4.0-62-generic 4.4.0-87-generic
 
 RUN apt-get update \
 && apt-get install -y --no-install-recommends openssl ca-certificates kmod \


### PR DESCRIPTION
Boots on digital ocean are really slow because they upgraded their
kernel.  This patch updates to the latest version.