### PR TITLE
init: Tell bash initializer.js is a node source file

### DIFF
--- a/quiltctl/command/init/initializer.js
+++ b/quiltctl/command/init/initializer.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const path = require('path');
 const os = require('os');
 const execSync = require('child_process').execSync;


### PR DESCRIPTION
By adding this comment at the top of initializer.js, it can be run
directly without needing to call type node.