### PR TITLE
lint: Avoid redundant error checks

### DIFF
--- a/cloud/google/google.go
+++ b/cloud/google/google.go
@@ -160,10 +160,8 @@ func (prvdr *Provider) Boot(bootSet []db.Machine) error {
 		}
 		names = append(names, name)
 	}
-	if err := prvdr.wait(names, true); err != nil {
-		return err
-	}
-	return nil
+
+	return prvdr.wait(names, true)
 }
 
 // Stop blocks while deleting the instances.
@@ -184,10 +182,7 @@ func (prvdr *Provider) Stop(machines []db.Machine) error {
 		}
 		names = append(names, m.CloudID)
 	}
-	if err := prvdr.wait(names, false); err != nil {
-		return err
-	}
-	return nil
+	return prvdr.wait(names, false)
 }
 
 // Get() and operationWait() don't always present the same results, so
@@ -628,10 +623,7 @@ func (prvdr *Provider) createInternalFirewall() error {
 		ops = append(ops, op)
 	}
 
-	if err := prvdr.operationWait(ops, global); err != nil {
-		return err
-	}
-	return nil
+	return prvdr.operationWait(ops, global)
 }
 
 func networkURL(networkName string) string {

--- a/db/machine_test.go
+++ b/db/machine_test.go
@@ -53,10 +53,7 @@ func TestMachine(t *testing.T) {
 
 		db.Remove(m)
 
-		if err := SelectMachineCheck(db, nil, nil); err != nil {
-			return err
-		}
-		return nil
+		return SelectMachineCheck(db, nil, nil)
 	})
 	if err != nil {
 		t.Error(err.Error())

--- a/minion/network/openflow/openflow.go
+++ b/minion/network/openflow/openflow.go
@@ -332,9 +332,5 @@ var ofctl = func(action string, flows []string) error {
 	}
 	stdin.Close()
 
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Wait()
 }

--- a/minion/pprofile/pprofile.go
+++ b/minion/pprofile/pprofile.go
@@ -81,8 +81,5 @@ func (pro *Prof) TimedRun(duration time.Duration) error {
 		return err
 	}
 	<-timer.C
-	if err := pro.Stop(); err != nil {
-		return err
-	}
-	return nil
+	return pro.Stop()
 }


### PR DESCRIPTION
The go linter updated with a new rule that checks for unnecessary
checks of error return values.  This patch updates the code to make
the linter happy.